### PR TITLE
safer on-demand compile

### DIFF
--- a/src/Code.php
+++ b/src/Code.php
@@ -15,9 +15,19 @@ final class Code
      */
     private $node;
 
-    public function __construct(Node $node)
+    /**
+     * @var bool
+     */
+    public $isSingleton;
+
+    /**
+     * @param Node $node
+     * @param bool $isSingleton
+     */
+    public function __construct(Node $node, $isSingleton = false)
     {
         $this->node = $node;
+        $this->isSingleton = $isSingleton;
     }
 
     public function __toString()

--- a/src/DependencyCompiler.php
+++ b/src/DependencyCompiler.php
@@ -265,6 +265,7 @@ final class DependencyCompiler
         if ($dependency instanceof Instance) {
             return $this->normalizer->normalizeValue($dependency->value);
         }
+
         return $this->getPullDependency($argument, $dependency);
     }
 

--- a/src/DependencyCompiler.php
+++ b/src/DependencyCompiler.php
@@ -30,15 +30,21 @@ final class DependencyCompiler
     private $container;
 
     /**
+     * @var ScriptInjector
+     */
+    private $injector;
+
+    /**
      * @var Normalizer
      */
     private $normalizer;
 
-    public function __construct(Container $container)
+    public function __construct(Container $container, ScriptInjector $injector = null)
     {
         $this->factory = new \PhpParser\BuilderFactory;
         $this->container = $container;
         $this->normalizer = new Normalizer;
+        $this->injector = $injector;
     }
 
     /**
@@ -72,7 +78,7 @@ final class DependencyCompiler
     {
         $node = $this->normalizer->normalizeValue($instance->value);
 
-        return new Code(new Node\Stmt\Return_($node));
+        return new Code(new Node\Stmt\Return_($node), false);
     }
 
     /**
@@ -88,8 +94,9 @@ final class DependencyCompiler
         $this->getAopCode($dependency, $node);
         $node[] = new Node\Stmt\Return_(new Node\Expr\Variable('instance'));
         $node = $this->factory->namespace('Ray\Di\Compiler')->addStmts($node)->getNode();
+        $isSingleton = $this->getPrivateProperty($dependency, 'isSingleton');
 
-        return new Code($node);
+        return new Code($node, $isSingleton);
     }
 
     /**
@@ -105,8 +112,9 @@ final class DependencyCompiler
         $node = $this->getFactoryNode($dependency);
         $node[] = new Stmt\Return_(new Expr\MethodCall(new Expr\Variable('instance'), 'get'));
         $node = $this->factory->namespace('Ray\Di\Compiler')->addStmts($node)->getNode();
+        $isSingleton = $this->getPrivateProperty($provider, 'isSingleton');
 
-        return new Code($node);
+        return new Code($node, $isSingleton);
     }
 
     /**
@@ -145,7 +153,6 @@ final class DependencyCompiler
         $instance = new Expr\Variable('instance');
         // constructor injection
         $constructorInjection =  $this->constructorInjection($class, $arguments);
-        $node[] = new Expr\Assign(new Expr\Variable('is_singleton'), $this->normalizer->normalizeValue($isSingleton));
         $node[] = new Expr\Assign($instance, $constructorInjection);
         $setters = $this->setterInjection($instance, $setterMethods);
         foreach ($setters as $setter) {
@@ -251,16 +258,49 @@ final class DependencyCompiler
             return $this->getInjectionPoint();
         }
         $hasDependency = isset($this->container->getContainer()[$dependencyIndex]);
-        if (! $hasDependency && $argument->isDefaultAvailable()) {
-            $default = $argument->getDefaultValue();
-            $node = $this->normalizer->normalizeValue($default);
-
-            return $node;
+        if (! $hasDependency) {
+            return $this->getOnDemandDependency($argument);
         }
         $dependency = $this->container->getContainer()[$dependencyIndex];
         if ($dependency instanceof Instance) {
             return $this->normalizer->normalizeValue($dependency->value);
         }
+        return $this->getPullDependency($argument, $dependency);
+    }
+
+    /**
+     * Return on-demand dependency pull code for not compiled
+     *
+     * @param Argument $argument
+     *
+     * @return Expr|Expr\FuncCall
+     */
+    private function getOnDemandDependency(Argument $argument)
+    {
+        if ($argument->isDefaultAvailable()) {
+            $default = $argument->getDefaultValue();
+            $node = $this->normalizer->normalizeValue($default);
+
+            return $node;
+        }
+        $dependencyIndex = (string) $argument;
+        $func = $this->injector->isSingleton($dependencyIndex) ? 'singleton' : 'prototype';
+        $args = $this->getInjectionProviderParams($argument);
+        $node = new Expr\FuncCall(new Expr\Variable($func), $args);
+
+        return $node;
+    }
+
+    /**
+     * Return arguments code for "$singleton" and "$prototype"
+     *
+     * @param Argument $argument
+     * @param bool     $isSingleton
+     *
+     * @return Expr\FuncCall
+     */
+    private function getPullDependency(Argument $argument, DependencyInterface $dependency)
+    {
         $isSingleton = $this->getPrivateProperty($dependency, 'isSingleton');
         $func = $isSingleton ? 'singleton' : 'prototype';
         $args = $this->getInjectionFuncParams($argument);
@@ -281,7 +321,9 @@ final class DependencyCompiler
     }
 
     /**
-     * Return arguments code for "$singleton" and "$prototype"
+     * Return dependency index argument
+     *
+     * [class, method, param] is added if dependency is provider for DI context
      *
      * @param Argument $argument
      *
@@ -290,8 +332,7 @@ final class DependencyCompiler
     private function getInjectionFuncParams(Argument $argument)
     {
         $dependencyIndex = (string) $argument;
-        $isProviderDependency = $this->container->getContainer()[$dependencyIndex] instanceof DependencyProvider;
-        if ($isProviderDependency) {
+        if ($this->container->getContainer()[$dependencyIndex] instanceof DependencyProvider) {
             return $this->getInjectionProviderParams($argument);
         }
 

--- a/src/DependencySaver.php
+++ b/src/DependencySaver.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of the Ray.Compiler package.
+ *
+ * @license http://opensource.org/licenses/bsd-license.php MIT
+ *
+ * taken from BuilderAbstract::PhpParser() and modified for object
+ */
+namespace Ray\Compiler;
+
+class DependencySaver
+{
+    private $scriptDir;
+
+    /**
+     * @param string $scriptDir
+     */
+    public function __construct($scriptDir)
+    {
+        $this->scriptDir = $scriptDir;
+    }
+
+    /**
+     * @param string $dependencyIndex
+     * @param Code   $code
+     */
+    public function __invoke($dependencyIndex, Code $code)
+    {
+        $file = sprintf('%s/%s.php', $this->scriptDir, str_replace('\\', '_', $dependencyIndex));
+        file_put_contents($file, (string) $code, LOCK_EX);
+        $meta = json_encode(['is_singleton' => $code->isSingleton]);
+        file_put_contents($file . '.meta.php', $meta, LOCK_EX);
+    }
+}

--- a/src/DependencySaver.php
+++ b/src/DependencySaver.php
@@ -26,7 +26,7 @@ class DependencySaver
      */
     public function __invoke($dependencyIndex, Code $code)
     {
-        $file = sprintf('%s/%s.php', $this->scriptDir, str_replace('\\', '_', $dependencyIndex));
+        $file = sprintf('%s/__%s.php', $this->scriptDir, str_replace('\\', '_', $dependencyIndex));
         file_put_contents($file, (string) $code, LOCK_EX);
         $meta = json_encode(['is_singleton' => $code->isSingleton]);
         file_put_contents($file . '.meta.php', $meta, LOCK_EX);

--- a/src/DiCompiler.php
+++ b/src/DiCompiler.php
@@ -18,7 +18,7 @@ final class DiCompiler implements InjectorInterface
     /**
      * @var string
      */
-    private $classDir;
+    private $scriptDir;
 
     /**
      * @var Container
@@ -42,16 +42,16 @@ final class DiCompiler implements InjectorInterface
 
     /**
      * @param AbstractModule $module
-     * @param string         $classDir
+     * @param string         $scriptDir
      */
-    public function __construct(AbstractModule $module = null, $classDir = null)
+    public function __construct(AbstractModule $module = null, $scriptDir = null)
     {
-        $this->classDir = $classDir ?: sys_get_temp_dir();
+        $this->scriptDir = $scriptDir ?: sys_get_temp_dir();
         $this->container =  $module ? $module->getContainer() : new Container;
-        $this->injector = new Injector($module, $classDir);
+        $this->injector = new Injector($module, $scriptDir);
         $this->dependencyCompiler = new DependencyCompiler($this->container);
         $this->module = $module;
-        $this->dependencySaver = new DependencySaver($classDir);
+        $this->dependencySaver = new DependencySaver($scriptDir);
     }
 
     /**

--- a/src/DiCompiler.php
+++ b/src/DiCompiler.php
@@ -51,6 +51,7 @@ final class DiCompiler implements InjectorInterface
         $this->injector = new Injector($module, $classDir);
         $this->dependencyCompiler = new DependencyCompiler($this->container);
         $this->module = $module;
+        $this->dependencySaver = new DependencySaver($classDir);
     }
 
     /**
@@ -76,11 +77,11 @@ final class DiCompiler implements InjectorInterface
     {
         $container = $this->container->getContainer();
         foreach ($container as $dependencyIndex => $dependency) {
-            $file = sprintf('%s/%s.php', $this->classDir, str_replace('\\', '_', $dependencyIndex));
             if (! $dependency instanceof DependencyInterface) {
                 continue;
             }
-            $this->putCompileFile($dependency, $file);
+            $code = $this->dependencyCompiler->compile($dependency);
+            $this->dependencySaver->__invoke($dependencyIndex, $code);
         }
     }
 

--- a/src/DiCompiler.php
+++ b/src/DiCompiler.php
@@ -87,7 +87,7 @@ final class DiCompiler implements InjectorInterface
 
     /**
      * @param DependencyInterface $dependency
-     * @param string $file
+     * @param string              $file
      */
     private function putCompileFile(DependencyInterface $dependency, $file)
     {

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -147,10 +147,7 @@ class ScriptInjector implements InjectorInterface
         }
         $dependency = (new Bind(new Container, $class))->getBound();
         $code = (new DependencyCompiler(new Container, $this))->compile($dependency);
-        $file = sprintf('%s/%s.php', $this->scriptDir, str_replace('\\', '_', $dependencyIndex));
-        file_put_contents($file, (string) $code);
-        $meta = json_encode(['is_singleton' => $code->isSingleton]);
-        file_put_contents($file . '.meta.php', $meta, LOCK_EX);
+        (new DependencySaver($this->scriptDir))->__invoke($dependencyIndex, $code);
         try {
             return $this->getScriptInstance($dependencyIndex);
         } catch (Unbound $e) {

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -74,7 +74,7 @@ class ScriptInjector implements InjectorInterface
         if ($dependencyIndex === 'Ray\Di\InjectorInterface-*') {
             return $this;
         }
-        $file = sprintf('%s/%s.php', $this->scriptDir, str_replace('\\', '_', $dependencyIndex));
+        $file = sprintf('%s/__%s.php', $this->scriptDir, str_replace('\\', '_', $dependencyIndex));
         if (! file_exists($file)) {
             return $this->onDemandCompile($dependencyIndex);
         }
@@ -125,7 +125,7 @@ class ScriptInjector implements InjectorInterface
      */
     public function isSingleton($dependencyIndex)
     {
-        $file = sprintf('%s/%s.php.meta.php', $this->scriptDir, str_replace('\\', '_', $dependencyIndex));
+        $file = sprintf('%s/__%s.php.meta.php', $this->scriptDir, str_replace('\\', '_', $dependencyIndex));
         $meta = json_decode(file_get_contents($file));
         $isSingleton = $meta->is_singleton;
 

--- a/tests/DependencyCompilerTest.php
+++ b/tests/DependencyCompilerTest.php
@@ -60,7 +60,6 @@ EOT;
 
 namespace Ray\Di\Compiler;
 
-$is_singleton = false;
 $instance = new \Ray\Compiler\FakeCar($prototype('Ray\\Compiler\\FakeEngineInterface-*'));
 $instance->setTires($prototype('Ray\\Compiler\\FakeTyreInterface-*'), $prototype('Ray\\Compiler\\FakeTyreInterface-*'), null);
 $instance->setHardtop($prototype('Ray\\Compiler\\FakeHardtopInterface-*'));
@@ -83,7 +82,6 @@ EOT;
 
 namespace Ray\Di\Compiler;
 
-$is_singleton = false;
 $instance = new \Ray\Compiler\FakeHandleProvider('momo');
 return $instance->get();
 EOT;

--- a/tests/DiCompilerTest.php
+++ b/tests/DiCompilerTest.php
@@ -19,13 +19,13 @@ class DiCompilerTest extends \PHPUnit_Framework_TestCase
         $compiler = new DiCompiler(new FakeCarModule, $_ENV['TMP_DIR']);
         $compiler->compile();
         $files = [
-            'Ray_Compiler_FakeCarInterface-*.php',
-            'Ray_Compiler_FakeEngineInterface-*.php',
-            'Ray_Compiler_FakeHandleInterface-*.php',
-            'Ray_Compiler_FakeHardtopInterface-*.php',
-            'Ray_Compiler_FakeMirrorInterface-right.php',
-            'Ray_Compiler_FakeMirrorInterface-left.php',
-            'Ray_Compiler_FakeTyreInterface-*.php',
+            '__Ray_Compiler_FakeCarInterface-*.php',
+            '__Ray_Compiler_FakeEngineInterface-*.php',
+            '__Ray_Compiler_FakeHandleInterface-*.php',
+            '__Ray_Compiler_FakeHardtopInterface-*.php',
+            '__Ray_Compiler_FakeMirrorInterface-right.php',
+            '__Ray_Compiler_FakeMirrorInterface-left.php',
+            '__Ray_Compiler_FakeTyreInterface-*.php',
         ];
         foreach ($files as $file) {
             $filePath = $_ENV['TMP_DIR'] . '/'. $file;
@@ -48,8 +48,8 @@ class DiCompilerTest extends \PHPUnit_Framework_TestCase
         $compiler = new DiCompiler(new FakeAopModule, $_ENV['TMP_DIR']);
         $compiler->compile();
         $files = [
-            'Ray_Compiler_FakeAopInterface-*.php',
-            'Ray_Compiler_FakeDoubleInterceptor-*.php'
+            '__Ray_Compiler_FakeAopInterface-*.php',
+            '__Ray_Compiler_FakeDoubleInterceptor-*.php'
         ];
         foreach ($files as $file) {
             $this->assertFileExists($_ENV['TMP_DIR'] . '/' . $file);

--- a/tests/DiCompilerTest.php
+++ b/tests/DiCompilerTest.php
@@ -28,7 +28,8 @@ class DiCompilerTest extends \PHPUnit_Framework_TestCase
             'Ray_Compiler_FakeTyreInterface-*.php',
         ];
         foreach ($files as $file) {
-            $this->assertTrue(file_exists($_ENV['TMP_DIR'] . '/'. $file));
+            $filePath = $_ENV['TMP_DIR'] . '/'. $file;
+            $this->assertTrue(file_exists($filePath), $filePath);
         }
         $injector = new ScriptInjector($_ENV['TMP_DIR']);
         $car = $injector->getInstance(FakeCarInterface::class);

--- a/tests/Fake/FakeDependPrototype.php
+++ b/tests/Fake/FakeDependPrototype.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Ray\Compiler;
+
+class FakeDependPrototype
+{
+    /**
+     * @var FakeCarInterface
+     */
+    public $car;
+
+    public function __construct(FakeCarInterface $car)
+    {
+        $this->car = $car;
+    }
+}

--- a/tests/Fake/FakeDependSingleton.php
+++ b/tests/Fake/FakeDependSingleton.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Ray\Compiler;
+
+class FakeDependSingleton
+{
+    /**
+     * @var FakeRobotInterface
+     */
+    public $robot;
+
+    public function __construct(FakeRobotInterface $robot)
+    {
+        $this->robot = $robot;
+    }
+}

--- a/tests/Fake/FakeInterceptor.php
+++ b/tests/Fake/FakeInterceptor.php
@@ -11,6 +11,7 @@ class FakeInterceptor implements MethodInterceptor
     public function invoke(MethodInvocation $invocation)
     {
         self::$args = $invocation->getArguments();
+
         return $invocation->proceed();
     }
 }


### PR DESCRIPTION
A dependency meta information is saved separately as .meta.php file. It
enables to remove module object serialized module.php file, which can
be problematic if dev bind unserialized object with toInstance() bing.
(or some class implement wild unserialize interface, which cause error)
