### PR TITLE
Remove php extension from instance script

### DIFF
--- a/src/DependencySaver.php
+++ b/src/DependencySaver.php
@@ -12,12 +12,16 @@ final class DependencySaver
 {
     private $scriptDir;
 
+    const META_FILE = '%s/metas/__%s.json';
+
     /**
      * @param string $scriptDir
      */
     public function __construct($scriptDir)
     {
         $this->scriptDir = $scriptDir;
+        $metasDir = $this->scriptDir . '/metas';
+        ! file_exists($metasDir) && mkdir($metasDir);
     }
 
     /**
@@ -26,9 +30,11 @@ final class DependencySaver
      */
     public function __invoke($dependencyIndex, Code $code)
     {
-        $file = sprintf('%s/__%s.php', $this->scriptDir, str_replace('\\', '_', $dependencyIndex));
-        file_put_contents($file, (string) $code, LOCK_EX);
+        $pearStyleName = str_replace('\\', '_', $dependencyIndex);
+        $instanceScript = sprintf('%s/__%s.php', $this->scriptDir, $pearStyleName);
+        file_put_contents($instanceScript, (string) $code, LOCK_EX);
         $meta = json_encode(['is_singleton' => $code->isSingleton]);
-        file_put_contents($file . '.meta.php', $meta, LOCK_EX);
+        $metaFile = sprintf(self::META_FILE, $this->scriptDir, $pearStyleName);
+        file_put_contents($metaFile, $meta, LOCK_EX);
     }
 }

--- a/src/DependencySaver.php
+++ b/src/DependencySaver.php
@@ -12,7 +12,8 @@ final class DependencySaver
 {
     private $scriptDir;
 
-    const META_FILE = '%s/metas/__%s.json';
+    const INSTANCE_FILE = '%s/%s';
+    const META_FILE = '%s/metas/%s.json';
 
     /**
      * @param string $scriptDir
@@ -31,10 +32,10 @@ final class DependencySaver
     public function __invoke($dependencyIndex, Code $code)
     {
         $pearStyleName = str_replace('\\', '_', $dependencyIndex);
-        $instanceScript = sprintf('%s/__%s.php', $this->scriptDir, $pearStyleName);
+        $instanceScript = sprintf(self::INSTANCE_FILE, $this->scriptDir, $pearStyleName);
         file_put_contents($instanceScript, (string) $code, LOCK_EX);
         $meta = json_encode(['is_singleton' => $code->isSingleton]);
-        $metaFile = sprintf(self::META_FILE, $this->scriptDir, $pearStyleName);
-        file_put_contents($metaFile, $meta, LOCK_EX);
+        $metaJson = sprintf(self::META_FILE, $this->scriptDir, $pearStyleName);
+        file_put_contents($metaJson, $meta, LOCK_EX);
     }
 }

--- a/src/DiCompiler.php
+++ b/src/DiCompiler.php
@@ -14,6 +14,8 @@ use Ray\Di\Name;
 
 final class DiCompiler implements InjectorInterface
 {
+    const POINT_CUT = '/metas/pointcut';
+
     /**
      * @var string
      */
@@ -98,6 +100,6 @@ final class DiCompiler implements InjectorInterface
         $ref = (new \ReflectionProperty($container, 'pointcuts'));
         $ref->setAccessible(true);
         $pointcuts = $ref->getValue($container);
-        file_put_contents($this->scriptDir . '/pointcut.txt', serialize($pointcuts));
+        file_put_contents($this->scriptDir . self::POINT_CUT, serialize($pointcuts));
     }
 }

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -102,7 +102,7 @@ class ScriptInjector implements InjectorInterface
      */
     private function getScriptInstance($dependencyIndex)
     {
-        $file = sprintf('%s/__%s.php', $this->scriptDir, str_replace('\\', '_', $dependencyIndex));
+        $file = sprintf(DependencySaver::INSTANCE_FILE, $this->scriptDir, str_replace('\\', '_', $dependencyIndex));
         if (! file_exists($file)) {
             return $this->onDemandCompile($dependencyIndex);
         }
@@ -175,7 +175,7 @@ class ScriptInjector implements InjectorInterface
      */
     private function loadPointcuts()
     {
-        $pointcuts = $this->scriptDir . '/pointcut.txt';
+        $pointcuts = $this->scriptDir . DiCompiler::POINT_CUT;
         if (! file_exists($pointcuts)) {
             return false;
         }

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -132,7 +132,8 @@ class ScriptInjector implements InjectorInterface
      */
     public function isSingleton($dependencyIndex)
     {
-        $file = sprintf('%s/__%s.php.meta.php', $this->scriptDir, str_replace('\\', '_', $dependencyIndex));
+        $pearStyleClass = str_replace('\\', '_', $dependencyIndex);
+        $file = sprintf(DependencySaver::META_FILE, $this->scriptDir, $pearStyleClass);
         if (! file_exists($file)) {
             throw new NotCompiled($dependencyIndex);
         }

--- a/tests/DiCompilerTest.php
+++ b/tests/DiCompilerTest.php
@@ -21,13 +21,13 @@ class DiCompilerTest extends \PHPUnit_Framework_TestCase
         $compiler->compile();
         $any = Name::ANY;
         $files = [
-            "__Ray_Compiler_FakeCarInterface-{$any}.php",
-            "__Ray_Compiler_FakeEngineInterface-{$any}.php",
-            "__Ray_Compiler_FakeHandleInterface-{$any}.php",
-            "__Ray_Compiler_FakeHardtopInterface-{$any}.php",
-            '__Ray_Compiler_FakeMirrorInterface-right.php',
-            '__Ray_Compiler_FakeMirrorInterface-left.php',
-            "__Ray_Compiler_FakeTyreInterface-{$any}.php",
+            "Ray_Compiler_FakeCarInterface-{$any}",
+            "Ray_Compiler_FakeEngineInterface-{$any}",
+            "Ray_Compiler_FakeHandleInterface-{$any}",
+            "Ray_Compiler_FakeHardtopInterface-{$any}",
+            'Ray_Compiler_FakeMirrorInterface-right',
+            'Ray_Compiler_FakeMirrorInterface-left',
+            "Ray_Compiler_FakeTyreInterface-{$any}",
         ];
         foreach ($files as $file) {
             $filePath = $_ENV['TMP_DIR'] . '/'. $file;
@@ -51,8 +51,8 @@ class DiCompilerTest extends \PHPUnit_Framework_TestCase
         $compiler->compile();
         $any = Name::ANY;
         $files = [
-            "__Ray_Compiler_FakeAopInterface-{$any}.php",
-            "__Ray_Compiler_FakeDoubleInterceptor-{$any}.php"
+            "Ray_Compiler_FakeAopInterface-{$any}",
+            "Ray_Compiler_FakeDoubleInterceptor-{$any}"
         ];
         foreach ($files as $file) {
             $this->assertFileExists($_ENV['TMP_DIR'] . '/' . $file);


### PR DESCRIPTION
It can avoids unnecessary scanning by IDE.

Move meta fails to`metas/` directory.