### PR TITLE
Refactor Normalizer

### DIFF
--- a/src/Exception/InvalidInstance.php
+++ b/src/Exception/InvalidInstance.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * This file is part of the Ray.Compiler package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\Compiler\Exception;
+
+class InvalidInstance extends \LogicException implements ExceptionInterface
+{
+}

--- a/src/Normalizer.php
+++ b/src/Normalizer.php
@@ -10,6 +10,7 @@ use PhpParser\Node;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr;
 use PhpParser\Node\Scalar;
+use Ray\Compiler\Exception\InvalidInstance;
 use Ray\Di\InjectorInterface;
 
 /**
@@ -24,14 +25,10 @@ final class Normalizer
      * @param mixed $value The value to normalize
      *
      * @return Expr The normalized value
-     *
-     * @codeCoverageIgnore
      */
     public function __invoke($value)
     {
-        if ($value instanceof Node) {
-            return $value;
-        } elseif ($value === null) {
+        if ($value === null) {
             return new Expr\ConstFetch(
                 new Node\Name('null')
             );
@@ -45,29 +42,26 @@ final class Normalizer
             return new Scalar\DNumber($value);
         } elseif (is_string($value)) {
             return new Scalar\String_($value);
-        } elseif (is_array($value)) {
-            $items = [];
-            $lastKey = -1;
-            foreach ($value as $itemKey => $itemValue) {
-                // for consecutive, numeric keys don't generate keys
-                if (null !== $lastKey && ++$lastKey === $itemKey) {
-                    $items[] = new Expr\ArrayItem(
-                        $this->__invoke($itemValue)
-                    );
-                } else {
-                    $lastKey = null;
-                    $items[] = new Expr\ArrayItem(
-                        $this->__invoke($itemValue),
-                        $this->__invoke($itemKey)
-                    );
-                }
-            }
+        }
 
-            return new Expr\Array_($items);
+        return $this->noScalar($value);
+    }
+
+    /**
+     * Return array or object node
+     *
+     * @param mixed $value
+     *
+     * @return Expr\Array_|Expr\FuncCall
+     */
+    private function noScalar($value)
+    {
+        if (is_array($value)) {
+            return $this->arrayValue($value);
         } elseif (is_object($value)) {
             return $this->normalizeObject($value);
         }
-        throw new \LogicException('Invalid value');
+        throw new InvalidInstance; //@codeCoverageIgnore
     }
 
     /**
@@ -85,5 +79,34 @@ final class Normalizer
         $serialize = new Scalar\String_(serialize($object));
 
         return new Expr\FuncCall(new Node\Name('unserialize'), [new Arg($serialize)]);
+    }
+
+    /**
+     * Return array value node
+     *
+     * @param $value
+     *
+     * @return Expr\Array_
+     */
+    private function arrayValue($value)
+    {
+        $items = [];
+        $lastKey = -1;
+        foreach ($value as $itemKey => $itemValue) {
+            // for consecutive, numeric keys don't generate keys
+            if (null !== $lastKey && ++$lastKey === $itemKey) {
+                $items[] = new Expr\ArrayItem(
+                    $this->__invoke($itemValue)
+                );
+            } else {
+                $lastKey = null;
+                $items[] = new Expr\ArrayItem(
+                    $this->__invoke($itemValue),
+                    $this->__invoke($itemKey)
+                );
+            }
+        }
+
+        return new Expr\Array_($items);
     }
 }

--- a/tests/DiCompilerTest.php
+++ b/tests/DiCompilerTest.php
@@ -112,8 +112,9 @@ class DiCompilerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider instanceProvider
-     * @param mixed $name
-     * @param mixed $expected
+     *
+     * @param string $name
+     * @param mixed  $expected
      */
     public function testInstance($name, $expected)
     {

--- a/tests/DiCompilerTest.php
+++ b/tests/DiCompilerTest.php
@@ -96,4 +96,33 @@ class DiCompilerTest extends \PHPUnit_Framework_TestCase
         $any = Name::ANY;
         $this->assertFileExists($_ENV['TMP_DIR'] . '/graph/Ray_Compiler_FakeCarInterface-' . $any . '.html');
     }
+
+    public function instanceProvider()
+    {
+        return [
+            ['bool', true],
+            ['null', null],
+            ['int', 1],
+            ['float', 1.0],
+            ['string', 'ray'],
+            ['no_index_array', [1, 2]],
+            ['assoc', ['a' => 1]]
+        ];
+    }
+
+    /**
+     * @dataProvider instanceProvider
+     * @param mixed $name
+     * @param mixed $expected
+     */
+    public function testInstance($name, $expected)
+    {
+        $compiler = new DiCompiler(new FakeInstanceModule, $_ENV['TMP_DIR']);
+        $compiler->compile();
+        $injector = new ScriptInjector($_ENV['TMP_DIR']);
+        $result = $injector->getInstance('', $name);
+        $this->assertSame($expected, $result);
+        $object = $injector->getInstance('', 'object');
+        $this->assertInstanceOf(\DateTime::class, $object);
+    }
 }

--- a/tests/Fake/FakeInstanceModule.php
+++ b/tests/Fake/FakeInstanceModule.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Ray\Compiler;
+
+use Ray\Di\AbstractModule;
+
+class FakeInstanceModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->bind()->annotatedWith('bool')->toInstance(true);
+        $this->bind()->annotatedWith('null')->toInstance(null);
+        $this->bind()->annotatedWith('int')->toInstance(1);
+        $this->bind()->annotatedWith('float')->toInstance(1.0);
+        $this->bind()->annotatedWith('string')->toInstance('ray');
+        $this->bind()->annotatedWith('no_index_array')->toInstance([1, 2]);
+        $this->bind()->annotatedWith('assoc')->toInstance(['a' => 1]);
+        $this->bind()->annotatedWith('object')->toInstance(new \DateTime());
+    }
+}

--- a/tests/NormalizerTest.php
+++ b/tests/NormalizerTest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This file is part of the Ray.Compiler package.
+ *
+ * @license http://opensource.org/licenses/MIT MIT
+ */
+namespace Ray\Compiler;
+
+use PhpParser\Node\Scalar\String_;
+
+class NormalizerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testString()
+    {
+        $normalizer = new Normalizer;
+        $string = $normalizer('ray');
+        /* @var $string String_ */
+        $this->assertInstanceOf(String_::class, $string);
+        $this->assertSame('ray', $string->value);
+    }
+
+    /**
+     * @expectedException \Ray\Compiler\Exception\InvalidInstance
+     */
+    public function testInvalidValue()
+    {
+        $normalizer = new Normalizer;
+        $resource = fopen(__FILE__, 'r');
+        $normalizer($resource);
+    }
+}


### PR DESCRIPTION
Normalizer convert to any instance value use in `toInstance()` method.
`$object` object is converted with `unserialized()`;