### PR TITLE
Multiple injectors share singleton instance in same context

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "ray/compiler",
     "description": "A dependency injection compiler for Ray.Di",
-    "version": "1.2.0",
+    "version": "1.1.4",
     "keywords": [
         "Ray.Di",
         "compiler",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "ray/compiler",
     "description": "A dependency injection compiler for Ray.Di",
+    "version": "1.2.0",
     "keywords": [
         "Ray.Di",
         "compiler",

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -118,6 +118,17 @@ final class ScriptInjector implements InjectorInterface, \Serializable
         return $isSingleton;
     }
 
+    public function serialize()
+    {
+        return \serialize([$this->scriptDir, $this->injectorId, self::$singletons[$this->injectorId]]);
+    }
+
+    public function unserialize($serialized)
+    {
+        list($this->scriptDir, $this->injectorId, self::$singletons[$this->injectorId]) = \unserialize($serialized);
+        $this->__construct($this->scriptDir);
+    }
+
     /**
      * @param string $dependencyIndex
      *
@@ -189,16 +200,5 @@ final class ScriptInjector implements InjectorInterface, \Serializable
         }
 
         return  \unserialize(\file_get_contents($pointcuts));
-    }
-
-    public function serialize()
-    {
-        return \serialize([$this->scriptDir, $this->injectorId, self::$singletons[$this->injectorId]]);
-    }
-
-    public function unserialize($serialized)
-    {
-        list($this->scriptDir, $this->injectorId, self::$singletons[$this->injectorId]) = \unserialize($serialized);
-        $this->__construct($this->scriptDir);
     }
 }

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -54,7 +54,7 @@ final class ScriptInjector implements InjectorInterface, \Serializable
     public function __construct($scriptDir)
     {
         $this->scriptDir = $scriptDir;
-        $this->injectorId = crc32($this->scriptDir);
+        $this->injectorId = \crc32($this->scriptDir);
         $this->registerLoader();
         $prototype = function ($dependencyIndex, array $injectionPoint = []) {
             $this->ip = $injectionPoint;
@@ -86,13 +86,13 @@ final class ScriptInjector implements InjectorInterface, \Serializable
     /**
      * Set precompiled singleton object
      *
-     * @param mixed  $object
-     * @param string $interaface
-     * @param string string $name
+     * @param mixed  $instance   dependency instance
+     * @param string $interaface depedency interface
+     * @param string $name       dependency name
      */
-    public function setSingleton($object, $interaface, $name = '')
+    public function setSingleton($instance, $interaface, $name = '')
     {
-        self::$singletons[$this->injectorId][$interaface. '-' . $name] = $object;
+        self::$singletons[$this->injectorId][$interaface . '-' . $name] = $instance;
     }
 
     /**
@@ -128,6 +128,17 @@ final class ScriptInjector implements InjectorInterface, \Serializable
         $isSingleton = $meta->is_singleton;
 
         return $isSingleton;
+    }
+
+    public function serialize()
+    {
+        return \serialize([$this->scriptDir, $this->injectorId, self::$singletons[$this->injectorId]]);
+    }
+
+    public function unserialize($serialized)
+    {
+        list($this->scriptDir, $this->injectorId, self::$singletons[$this->injectorId]) = \unserialize($serialized);
+        $this->__construct($this->scriptDir);
     }
 
     /**
@@ -200,15 +211,5 @@ final class ScriptInjector implements InjectorInterface, \Serializable
         }
 
         return  \unserialize(\file_get_contents($pointcuts));
-    }
-
-    public function serialize() {
-        return serialize([$this->scriptDir, $this->injectorId, self::$singletons[$this->injectorId]]);
-    }
-
-    public function unserialize($serialized)
-    {
-        list($this->scriptDir, $this->injectorId, self::$singletons[$this->injectorId]) = unserialize($serialized);
-        $this->__construct($this->scriptDir);
     }
 }

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -84,18 +84,6 @@ final class ScriptInjector implements InjectorInterface, \Serializable
     }
 
     /**
-     * Set precompiled singleton instance
-     *
-     * @param mixed  $instance   dependency instance
-     * @param string $interface depedency interface
-     * @param string $name       dependency name
-     */
-    public function setSingletonInstance($instance, $interface, $name = '')
-    {
-        self::$singletons[$this->injectorId][$interface . '-' . $name] = $instance;
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function getInstance($interface, $name = Name::ANY)

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -173,8 +173,6 @@ final class ScriptInjector implements InjectorInterface, \Serializable
     private function onDemandCompile($dependencyIndex)
     {
         list($class) = \explode('-', $dependencyIndex);
-        $a = \class_exists(FakeCarInterface::class);
-        $b = \class_exists($class);
         if (! \class_exists($class)) {
             throw new ClassNotFound($class);
         }

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -15,7 +15,7 @@ use Ray\Di\Dependency;
 use Ray\Di\InjectorInterface;
 use Ray\Di\Name;
 
-final class ScriptInjector implements InjectorInterface
+final class ScriptInjector implements InjectorInterface, \Serializable
 {
     /**
      * @var string
@@ -36,12 +36,17 @@ final class ScriptInjector implements InjectorInterface
      *
      * @var array
      */
-    private $singletons = [];
+    private static $singletons = [];
 
     /**
-     * @var
+     * @var array
      */
     private $functions;
+
+    /**
+     * @var int
+     */
+    private $injectorId;
 
     /**
      * @param string $scriptDir generated instance script folder path
@@ -49,6 +54,7 @@ final class ScriptInjector implements InjectorInterface
     public function __construct($scriptDir)
     {
         $this->scriptDir = $scriptDir;
+        $this->injectorId = crc32($this->scriptDir);
         $this->registerLoader();
         $prototype = function ($dependencyIndex, array $injectionPoint = []) {
             $this->ip = $injectionPoint;
@@ -56,12 +62,12 @@ final class ScriptInjector implements InjectorInterface
             return $this->getScriptInstance($dependencyIndex);
         };
         $singleton = function ($dependencyIndex, array $injectionPoint = []) {
-            if (isset($this->singletons[$dependencyIndex])) {
-                return $this->singletons[$dependencyIndex];
+            if (isset(self::$singletons[$this->injectorId][$dependencyIndex])) {
+                return self::$singletons[$this->injectorId][$dependencyIndex];
             }
             $this->ip = $injectionPoint;
             $instance = $this->getScriptInstance($dependencyIndex);
-            $this->singletons[$dependencyIndex] = $instance;
+            self::$singletons[$this->injectorId][$dependencyIndex] = $instance;
 
             return $instance;
         };
@@ -77,14 +83,16 @@ final class ScriptInjector implements InjectorInterface
         $this->functions = [$prototype, $singleton, $injection_point, $injector];
     }
 
-    public function __wakeup()
+    /**
+     * Set precompiled singleton object
+     *
+     * @param mixed  $object
+     * @param string $interaface
+     * @param string string $name
+     */
+    public function setSingleton($object, $interaface, $name = '')
     {
-        $this->__construct($this->scriptDir);
-    }
-
-    public function __sleep()
-    {
-        return ['scriptDir'];
+        self::$singletons[$this->injectorId][$interaface. '-' . $name] = $object;
     }
 
     /**
@@ -93,12 +101,12 @@ final class ScriptInjector implements InjectorInterface
     public function getInstance($interface, $name = Name::ANY)
     {
         $dependencyIndex = $interface . '-' . $name;
-        if (isset($this->singletons[$dependencyIndex])) {
-            return $this->singletons[$dependencyIndex];
+        if (isset(self::$singletons[$this->injectorId][$dependencyIndex])) {
+            return self::$singletons[$this->injectorId][$dependencyIndex];
         }
         $instance = $this->getScriptInstance($dependencyIndex);
         if ($this->isSingleton($dependencyIndex) === true) {
-            $this->singletons[$dependencyIndex] = $instance;
+            self::$singletons[$this->injectorId][$dependencyIndex] = $instance;
         }
 
         return $instance;
@@ -192,5 +200,15 @@ final class ScriptInjector implements InjectorInterface
         }
 
         return  \unserialize(\file_get_contents($pointcuts));
+    }
+
+    public function serialize() {
+        return serialize([$this->scriptDir, $this->injectorId, self::$singletons[$this->injectorId]]);
+    }
+
+    public function unserialize($serialized)
+    {
+        list($this->scriptDir, $this->injectorId, self::$singletons[$this->injectorId]) = unserialize($serialized);
+        $this->__construct($this->scriptDir);
     }
 }

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -130,17 +130,6 @@ final class ScriptInjector implements InjectorInterface, \Serializable
         return $isSingleton;
     }
 
-    public function serialize()
-    {
-        return \serialize([$this->scriptDir, $this->injectorId, self::$singletons[$this->injectorId]]);
-    }
-
-    public function unserialize($serialized)
-    {
-        list($this->scriptDir, $this->injectorId, self::$singletons[$this->injectorId]) = \unserialize($serialized);
-        $this->__construct($this->scriptDir);
-    }
-
     /**
      * @param string $dependencyIndex
      *
@@ -214,5 +203,16 @@ final class ScriptInjector implements InjectorInterface, \Serializable
         }
 
         return  \unserialize(\file_get_contents($pointcuts));
+    }
+
+    public function serialize()
+    {
+        return \serialize([$this->scriptDir, $this->injectorId, self::$singletons[$this->injectorId]]);
+    }
+
+    public function unserialize($serialized)
+    {
+        list($this->scriptDir, $this->injectorId, self::$singletons[$this->injectorId]) = \unserialize($serialized);
+        $this->__construct($this->scriptDir);
     }
 }

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -84,15 +84,15 @@ final class ScriptInjector implements InjectorInterface, \Serializable
     }
 
     /**
-     * Set precompiled singleton object
+     * Set precompiled singleton instance
      *
      * @param mixed  $instance   dependency instance
-     * @param string $interaface depedency interface
+     * @param string $interface depedency interface
      * @param string $name       dependency name
      */
-    public function setSingleton($instance, $interaface, $name = '')
+    public function setSingletonInstance($instance, $interface, $name = '')
     {
-        self::$singletons[$this->injectorId][$interaface . '-' . $name] = $instance;
+        self::$singletons[$this->injectorId][$interface . '-' . $name] = $instance;
     }
 
     /**

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -159,6 +159,9 @@ final class ScriptInjector implements InjectorInterface, \Serializable
         return $instance;
     }
 
+    /**
+     * Register autoload for AOP file
+     */
     private function registerLoader()
     {
         \spl_autoload_register(function ($class) {


### PR DESCRIPTION
For example, You set injectors in several properties as a singleton instance.

```php
class A{}
class B{}
class C{}

$a = new A;
$b = new B;
$c = new C;
$a->c = $b->c = $c;

var_dump(spl_object_hash($a->c) === spl_object_hash($b->c)); // true
list($x, $y) = [unserialize(serialize($a)), unserialize(serialize($b))];
var_dump(spl_object_hash($x->c) === spl_object_hash($y->c)); // false
```

This become a problem for singleton instance in Injector.

This PR fix this issue.
