### PR TITLE
Compile on demand and Fix #41

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,11 @@
         },
         "files": ["tests/delete_dir.php"]
     },
+    "extra": {
+        "branch-alias": {
+            "dev-1.x": "1.x-dev"
+        }
+    },
     "scripts" :{
         "test": ["phpunit", "@cs", "phpstan analyse -l max src tests -c phpstan.neon --no-progress"],
         "coverage": ["php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-html=build/coverage"],

--- a/src/AopCode.php
+++ b/src/AopCode.php
@@ -40,7 +40,13 @@ final class AopCode
         }
         $methodBinding = $this->getMethodBinding($bindings);
         $bindingsProp = new Expr\PropertyFetch(new Expr\Variable('instance'), 'bindings');
-        $node[] = new Expr\Assign($bindingsProp, new Expr\Array_($methodBinding));
+        $bindingsAssign = new Expr\Assign($bindingsProp, new Expr\Array_($methodBinding));
+        $this->setBindingAssignAfterInitialization($node, [$bindingsAssign], 1);
+    }
+
+    private function setBindingAssignAfterInitialization(array &$array, array $insertValue, int $position) : void
+    {
+        $array = \array_merge(\array_splice($array, 0, $position), $insertValue, $array);
     }
 
     /**

--- a/src/DependencySaver.php
+++ b/src/DependencySaver.php
@@ -11,12 +11,13 @@ final class DependencySaver
     const INSTANCE_FILE = '%s/%s.php';
     const META_FILE = '%s/metas/%s.json';
     const QUALIFIER_FILE = '%s/qualifer/%s-%s-%s';
-    private $scriptDir;
 
     /**
-     * @param string $scriptDir
+     * @var string
      */
-    public function __construct($scriptDir)
+    private $scriptDir;
+
+    public function __construct(string $scriptDir)
     {
         $this->scriptDir = $scriptDir;
         $metasDir = $this->scriptDir . '/metas';
@@ -25,10 +26,6 @@ final class DependencySaver
         ! \file_exists($qualifier) && \mkdir($qualifier);
     }
 
-    /**
-     * @param string $dependencyIndex
-     * @param Code   $code
-     */
     public function __invoke($dependencyIndex, Code $code)
     {
         $pearStyleName = \str_replace('\\', '_', $dependencyIndex);

--- a/src/DependencySaver.php
+++ b/src/DependencySaver.php
@@ -30,8 +30,8 @@ final class DependencySaver
     {
         $pearStyleName = \str_replace('\\', '_', $dependencyIndex);
         $instanceScript = \sprintf(self::INSTANCE_FILE, $this->scriptDir, $pearStyleName);
-        \file_put_contents($instanceScript, (string) $code, LOCK_EX);
-        $meta = \json_encode(['is_singleton' => $code->isSingleton]);
+        \file_put_contents($instanceScript, (string) $code . PHP_EOL, LOCK_EX);
+        $meta = \json_encode(['is_singleton' => $code->isSingleton]) . PHP_EOL;
         $metaJson = \sprintf(self::META_FILE, $this->scriptDir, $pearStyleName);
         \file_put_contents($metaJson, $meta, LOCK_EX);
         if ($code->qualifiers) {
@@ -48,6 +48,6 @@ final class DependencySaver
             $qualifer->param->getDeclaringFunction()->name,
             $qualifer->param->name
         );
-        \file_put_contents($fileName, \serialize($qualifer->qualifier));
+        \file_put_contents($fileName, \serialize($qualifer->qualifier) . PHP_EOL);
     }
 }

--- a/src/DiCompiler.php
+++ b/src/DiCompiler.php
@@ -61,10 +61,9 @@ final class DiCompiler implements InjectorInterface
      */
     public function getInstance($interface, $name = Name::ANY)
     {
-        $instance = $this->injector->getInstance($interface, $name);
         $this->compile();
 
-        return $instance;
+        return (new ScriptInjector($this->scriptDir))->getInstance($interface, $name);
     }
 
     /**

--- a/src/DiCompiler.php
+++ b/src/DiCompiler.php
@@ -46,11 +46,7 @@ final class DiCompiler implements InjectorInterface
      */
     private $dependencySaver;
 
-    /**
-     * @param AbstractModule $module
-     * @param string         $scriptDir
-     */
-    public function __construct(AbstractModule $module = null, $scriptDir = '')
+    public function __construct(AbstractModule $module = null, string $scriptDir = '')
     {
         $this->scriptDir = $scriptDir ?: \sys_get_temp_dir();
         $this->container = $module ? $module->getContainer() : new Container;

--- a/src/GraphDumper.php
+++ b/src/GraphDumper.php
@@ -23,11 +23,7 @@ final class GraphDumper
      */
     private $scriptDir;
 
-    /**
-     * @param Container $container
-     * @param string    $scriptDir
-     */
-    public function __construct(Container $container, $scriptDir)
+    public function __construct(Container $container, string $scriptDir)
     {
         $this->container = $container;
         $this->scriptDir = $scriptDir;
@@ -39,7 +35,7 @@ final class GraphDumper
         foreach ($container as $dependencyIndex => $dependency) {
             $isNorInjector = $dependencyIndex !== 'Ray\Di\InjectorInterface-' . Name::ANY;
             if ($dependency instanceof DependencyInterface && $isNorInjector) {
-                $this->write($dependency, $dependencyIndex);
+                $this->write($dependencyIndex);
             }
         }
     }
@@ -47,12 +43,13 @@ final class GraphDumper
     /**
      * Write html
      */
-    private function write(DependencyInterface $dependency, string $dependencyIndex) : void
+    private function write(string $dependencyIndex) : void
     {
         if ($dependencyIndex === 'Ray\Aop\MethodInvocation-') {
             return;
         }
-        $instance = $dependency->inject($this->container);
+        list($interface, $name) = \explode('-', $dependencyIndex);
+        $instance = (new ScriptInjector($this->scriptDir))->getInstance($interface, $name);
         $graph = (string) (new Printo($instance))
             ->setRange(Printo::RANGE_ALL)
             ->setLinkDistance(130)

--- a/src/NodeFactory.php
+++ b/src/NodeFactory.php
@@ -95,13 +95,7 @@ final class NodeFactory
         return $setters;
     }
 
-    /**
-     * @param Expr\Variable $instance
-     * @param string        $postConstruct
-     *
-     * @return Expr\MethodCall
-     */
-    public function getPostConstruct(Expr\Variable $instance, $postConstruct) : Expr\MethodCall
+    public function getPostConstruct(Expr\Variable $instance, string $postConstruct) : Expr\MethodCall
     {
         return new Expr\MethodCall($instance, $postConstruct);
     }

--- a/src/OnDemandCompiler.php
+++ b/src/OnDemandCompiler.php
@@ -7,10 +7,10 @@
 namespace Ray\Compiler;
 
 use Ray\Aop\Compiler;
-use Ray\Compiler\Exception\ClassNotFound;
 use Ray\Compiler\Exception\Unbound;
+use Ray\Di\AbstractModule;
 use Ray\Di\Bind;
-use Ray\Di\Container;
+use Ray\Di\Exception\NotFound;
 
 final class OnDemandCompiler
 {
@@ -24,10 +24,16 @@ final class OnDemandCompiler
      */
     private $injector;
 
-    public function __construct(ScriptInjector $injector, string $sctiptDir)
+    /**
+     * @var AbstractModule
+     */
+    private $module;
+
+    public function __construct(ScriptInjector $injector, string $sctiptDir, AbstractModule $module)
     {
         $this->scriptDir = $sctiptDir;
         $this->injector = $injector;
+        $this->module = $module;
     }
 
     /**
@@ -36,19 +42,23 @@ final class OnDemandCompiler
     public function __invoke(string $dependencyIndex) : void
     {
         list($class) = \explode('-', $dependencyIndex);
-        if (! \class_exists($class)) {
-            $e = new ClassNotFound($dependencyIndex);
+        $containerObject = $this->module->getContainer();
+        try {
+            new Bind($containerObject, $class);
+        } catch (NotFound $e) {
             throw new Unbound($dependencyIndex, 0, $e);
         }
-        $container = new Container();
-        new Bind($container, $class);
-        /** @var \Ray\Di\Dependency $dependency */
-        $dependency = $container->getContainer()[$dependencyIndex];
+        $containerArray = $containerObject->getContainer();
+        /* @var \Ray\Di\Dependency $dependency */
+        if (! isset($containerArray[$dependencyIndex])) {
+            throw new Unbound($dependencyIndex, 0);
+        }
+        $dependency = $containerArray[$dependencyIndex];
         $pointCuts = $this->loadPointcuts();
         if ($pointCuts) {
             $dependency->weaveAspects(new Compiler($this->scriptDir), $pointCuts);
         }
-        $code = (new DependencyCode(new Container, $this->injector))->getCode($dependency);
+        $code = (new DependencyCode($containerObject, $this->injector))->getCode($dependency);
         (new DependencySaver($this->scriptDir))->__invoke($dependencyIndex, $code);
     }
 

--- a/src/OnDemandCompiler.php
+++ b/src/OnDemandCompiler.php
@@ -10,6 +10,7 @@ use Ray\Aop\Compiler;
 use Ray\Compiler\Exception\Unbound;
 use Ray\Di\AbstractModule;
 use Ray\Di\Bind;
+use Ray\Di\Dependency;
 use Ray\Di\Exception\NotFound;
 
 final class OnDemandCompiler
@@ -53,6 +54,7 @@ final class OnDemandCompiler
         if (! isset($containerArray[$dependencyIndex])) {
             throw new Unbound($dependencyIndex, 0);
         }
+        /** @var Dependency $dependency */
         $dependency = $containerArray[$dependencyIndex];
         $pointCuts = $this->loadPointcuts();
         if ($pointCuts) {

--- a/tests/DiCompilerTest.php
+++ b/tests/DiCompilerTest.php
@@ -13,7 +13,7 @@ use Ray\Di\Name;
 
 class DiCompilerTest extends TestCase
 {
-    public function testClassNotFound()
+    public function testUnbound()
     {
         $this->expectException(Unbound::class);
         $injector = new ScriptInjector($_ENV['TMP_DIR']);

--- a/tests/ScriptInjectorTest.php
+++ b/tests/ScriptInjectorTest.php
@@ -170,14 +170,21 @@ class ScriptInjectorTest extends TestCase
         $this->assertInstanceOf(InjectorInterface::class, $factory->injector);
     }
 
-    /**
-     * @expectedException \Ray\Compiler\Exception\Unbound
-     * @expectedExceptionMessage NOCLASS-NONAME
-     */
     public function testUnbound()
     {
         $this->expectException(Unbound::class);
+        $this->expectExceptionMessage('NOCLASS-NONAME');
         $injector = new ScriptInjector($_ENV['TMP_DIR']);
         $injector->getInstance('NOCLASS', 'NONAME');
+    }
+
+    public function testCompileOnDemand()
+    {
+        delete_dir($_ENV['TMP_DIR']);
+        $injector = new ScriptInjector($_ENV['TMP_DIR'], function () {
+            return new FakeCarModule;
+        });
+        $car = $injector->getInstance(FakeCar::class);
+        $this->assertTrue($car instanceof FakeCar);
     }
 }

--- a/tests/ScriptInjectorTest.php
+++ b/tests/ScriptInjectorTest.php
@@ -181,9 +181,12 @@ class ScriptInjectorTest extends TestCase
     public function testCompileOnDemand()
     {
         delete_dir($_ENV['TMP_DIR']);
-        $injector = new ScriptInjector($_ENV['TMP_DIR'], function () {
-            return new FakeCarModule;
-        });
+        $injector = new ScriptInjector(
+            $_ENV['TMP_DIR'],
+            function () {
+                return new FakeCarModule;
+            }
+        );
         $car = $injector->getInstance(FakeCar::class);
         $this->assertTrue($car instanceof FakeCar);
     }


### PR DESCRIPTION
Enable to compile the dependency when module return callable variable are passed 2nd parameter of ScriptInjector.

```php
$injector = new ScriptInjector(
    $_ENV['TMP_DIR'],
    function () {
        return new FakeCarModule;
    }
);
$car = $injector->getInstance(FakeCar::class);
```