### PR TITLE
Serializable script injector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "koriym/printo": "^1.0"
     },
     "require-dev": {
-        "ray/di": "^2.6.5",
+        "ray/di": "^2.6.7",
         "phpunit/phpunit": "^6.5"
     },
     "autoload": {

--- a/src/DependencySaver.php
+++ b/src/DependencySaver.php
@@ -8,10 +8,6 @@ namespace Ray\Compiler;
 
 final class DependencySaver
 {
-    const INSTANCE_FILE = '%s/%s.php';
-    const META_FILE = '%s/metas/%s.json';
-    const QUALIFIER_FILE = '%s/qualifer/%s-%s-%s';
-
     /**
      * @var string
      */
@@ -29,10 +25,10 @@ final class DependencySaver
     public function __invoke($dependencyIndex, Code $code)
     {
         $pearStyleName = \str_replace('\\', '_', $dependencyIndex);
-        $instanceScript = \sprintf(self::INSTANCE_FILE, $this->scriptDir, $pearStyleName);
+        $instanceScript = \sprintf(ScriptInjector::INSTANCE_FILE, $this->scriptDir, $pearStyleName);
         \file_put_contents($instanceScript, (string) $code . PHP_EOL, LOCK_EX);
         $meta = \json_encode(['is_singleton' => $code->isSingleton]) . PHP_EOL;
-        $metaJson = \sprintf(self::META_FILE, $this->scriptDir, $pearStyleName);
+        $metaJson = \sprintf(ScriptInjector::META_FILE, $this->scriptDir, $pearStyleName);
         \file_put_contents($metaJson, $meta, LOCK_EX);
         if ($code->qualifiers) {
             $this->saveQualifier($code->qualifiers);
@@ -42,7 +38,7 @@ final class DependencySaver
     private function saveQualifier(IpQualifier $qualifer)
     {
         $fileName = \sprintf(
-            self::QUALIFIER_FILE,
+            ScriptInjector::QUALIFIER_FILE,
             $this->scriptDir,
             \str_replace('\\', '_', $qualifer->param->getDeclaringClass()->name),
             $qualifer->param->getDeclaringFunction()->name,

--- a/src/DiCompiler.php
+++ b/src/DiCompiler.php
@@ -14,8 +14,6 @@ use Ray\Di\Name;
 
 final class DiCompiler implements InjectorInterface
 {
-    const POINT_CUT = '/metas/pointcut';
-
     /**
      * @var string
      */
@@ -90,6 +88,6 @@ final class DiCompiler implements InjectorInterface
         $ref = (new \ReflectionProperty($container, 'pointcuts'));
         $ref->setAccessible(true);
         $pointcuts = $ref->getValue($container);
-        \file_put_contents($this->scriptDir . self::POINT_CUT, \serialize($pointcuts));
+        \file_put_contents($this->scriptDir . ScriptInjector::POINT_CUT, \serialize($pointcuts));
     }
 }

--- a/src/DiCompiler.php
+++ b/src/DiCompiler.php
@@ -85,7 +85,7 @@ final class DiCompiler implements InjectorInterface
         $dumper();
     }
 
-    private function savePointcuts(Container $container)
+    public function savePointcuts(Container $container)
     {
         $ref = (new \ReflectionProperty($container, 'pointcuts'));
         $ref->setAccessible(true);

--- a/src/InjectionPoint.php
+++ b/src/InjectionPoint.php
@@ -64,7 +64,7 @@ final class InjectionPoint implements InjectionPointInterface
     public function getQualifier()
     {
         $file = \sprintf(
-            DependencySaver::QUALIFIER_FILE,
+            ScriptInjector::QUALIFIER_FILE,
             $this->scriptDir,
             \str_replace('\\', '_', $this->parameter->getDeclaringClass()->name),
             $this->parameter->getDeclaringFunction()->name,

--- a/src/OnDemandCompiler.php
+++ b/src/OnDemandCompiler.php
@@ -69,7 +69,7 @@ final class OnDemandCompiler
      */
     private function loadPointcuts()
     {
-        $pointcuts = $this->scriptDir . DiCompiler::POINT_CUT;
+        $pointcuts = $this->scriptDir . ScriptInjector::POINT_CUT;
         if (! \file_exists($pointcuts)) {
             return false;
         }

--- a/src/OnDemandCompiler.php
+++ b/src/OnDemandCompiler.php
@@ -57,7 +57,7 @@ final class OnDemandCompiler
         /** @var Dependency $dependency */
         $dependency = $containerArray[$dependencyIndex];
         $pointCuts = $this->loadPointcuts();
-        if ($pointCuts) {
+        if ($dependency instanceof Dependency) {
             $dependency->weaveAspects(new Compiler($this->scriptDir), $pointCuts);
         }
         $code = (new DependencyCode($containerObject, $this->injector))->getCode($dependency);

--- a/src/OnDemandCompiler.php
+++ b/src/OnDemandCompiler.php
@@ -57,7 +57,7 @@ final class OnDemandCompiler
         /** @var Dependency $dependency */
         $dependency = $containerArray[$dependencyIndex];
         $pointCuts = $this->loadPointcuts();
-        if ($dependency instanceof Dependency && is_array($pointCuts)) {
+        if ($dependency instanceof Dependency && \is_array($pointCuts)) {
             $dependency->weaveAspects(new Compiler($this->scriptDir), $pointCuts);
         }
         $code = (new DependencyCode($containerObject, $this->injector))->getCode($dependency);

--- a/src/OnDemandCompiler.php
+++ b/src/OnDemandCompiler.php
@@ -57,7 +57,7 @@ final class OnDemandCompiler
         /** @var Dependency $dependency */
         $dependency = $containerArray[$dependencyIndex];
         $pointCuts = $this->loadPointcuts();
-        if ($dependency instanceof Dependency) {
+        if ($dependency instanceof Dependency && is_array($pointCuts)) {
             $dependency->weaveAspects(new Compiler($this->scriptDir), $pointCuts);
         }
         $code = (new DependencyCode($containerObject, $this->injector))->getCode($dependency);

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -125,7 +125,7 @@ final class ScriptInjector implements InjectorInterface, \Serializable
 
     public function serialize() : string
     {
-        $module = $this->module instanceof AbstractModule ? $this->module : ($this->lazyModule)();
+        $module = ($this->lazyModule)();
         \file_put_contents($this->scriptDir . '/module', \serialize($module));
 
         return \serialize([$this->scriptDir, $this->singletons]);

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -6,10 +6,8 @@
  */
 namespace Ray\Compiler;
 
-use Ray\Aop\Compiler;
 use Ray\Compiler\Exception\MetaNotFound;
 use Ray\Di\AbstractModule;
-use Ray\Di\Container;
 use Ray\Di\EmptyModule;
 use Ray\Di\InjectorInterface;
 use Ray\Di\Name;
@@ -20,8 +18,7 @@ final class ScriptInjector implements InjectorInterface, \Serializable
     const INSTANCE_FILE = '%s/%s.php';
     const META_FILE = '%s/metas/%s.json';
     const QUALIFIER_FILE = '%s/qualifer/%s-%s-%s';
-    
-    
+
     /**
      * @var string
      */
@@ -123,13 +120,21 @@ final class ScriptInjector implements InjectorInterface, \Serializable
 
     public function serialize() : string
     {
+        $module = ($this->module)();
+        \file_put_contents($this->scriptDir . '/module', \serialize($module));
+
         return \serialize([$this->scriptDir, $this->singletons]);
     }
 
     public function unserialize($serialized)
     {
         list($this->scriptDir, $this->singletons) = \unserialize($serialized);
-        $this->__construct($this->scriptDir);
+        $this->__construct(
+            $this->scriptDir,
+            function () {
+                return \unserialize(\file_get_contents($this->scriptDir . '/module'));
+            }
+        );
     }
 
     /**

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -177,21 +177,15 @@ final class ScriptInjector implements InjectorInterface, \Serializable
         if (\file_exists($file)) {
             return $file;
         }
-        if ($this->isFirstCompile()) {
+        $isFirstCompile = ! \file_exists($this->scriptDir . self::POINT_CUT);
+        if ($isFirstCompile) {
             /** @var AbstractModule $module */
             $module = ($this->module)();
             (new DiCompiler(($this->module)(), $this->scriptDir))->savePointcuts($module->getContainer());
         }
-        if (! \file_exists($file)) {
-            (new OnDemandCompiler($this, $this->scriptDir, ($this->module)()))($dependencyIndex);
-        }
+        (new OnDemandCompiler($this, $this->scriptDir, ($this->module)()))($dependencyIndex);
 
         return $file;
-    }
-
-    private function isFirstCompile() : bool
-    {
-        return ! \file_exists($this->scriptDir . self::POINT_CUT);
     }
 
     /**

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -16,6 +16,12 @@ use Ray\Di\Name;
 
 final class ScriptInjector implements InjectorInterface, \Serializable
 {
+    const POINT_CUT = '/metas/pointcut';
+    const INSTANCE_FILE = '%s/%s.php';
+    const META_FILE = '%s/metas/%s.json';
+    const QUALIFIER_FILE = '%s/qualifer/%s-%s-%s';
+    
+    
     /**
      * @var string
      */
@@ -105,7 +111,7 @@ final class ScriptInjector implements InjectorInterface, \Serializable
     public function isSingleton($dependencyIndex) : bool
     {
         $pearStyleClass = \str_replace('\\', '_', $dependencyIndex);
-        $file = \sprintf(DependencySaver::META_FILE, $this->scriptDir, $pearStyleClass);
+        $file = \sprintf(self::META_FILE, $this->scriptDir, $pearStyleClass);
         if (! \file_exists($file)) {
             throw new MetaNotFound($dependencyIndex);
         }
@@ -162,7 +168,7 @@ final class ScriptInjector implements InjectorInterface, \Serializable
      */
     private function getInstanceFile(string $dependencyIndex) : string
     {
-        $file = \sprintf(DependencySaver::INSTANCE_FILE, $this->scriptDir, \str_replace('\\', '_', $dependencyIndex));
+        $file = \sprintf(self::INSTANCE_FILE, $this->scriptDir, \str_replace('\\', '_', $dependencyIndex));
         if (\file_exists($file)) {
             return $file;
         }
@@ -180,7 +186,7 @@ final class ScriptInjector implements InjectorInterface, \Serializable
 
     private function isFirstCompile() : bool
     {
-        return ! \file_exists($this->scriptDir . DiCompiler::POINT_CUT);
+        return ! \file_exists($this->scriptDir . self::POINT_CUT);
     }
 
     /**

--- a/tests/ScriptInjectorTest.php
+++ b/tests/ScriptInjectorTest.php
@@ -152,7 +152,6 @@ class ScriptInjectorTest extends TestCase
 
     public function testOptional()
     {
-        delete_dir($_ENV['TMP_DIR']);
         /* @var $optional FakeOptional */
         $optional = $this->injector->getInstance(FakeOptional::class);
         $this->assertNull($optional->robot);

--- a/tests/ScriptInjectorTest.php
+++ b/tests/ScriptInjectorTest.php
@@ -180,7 +180,6 @@ class ScriptInjectorTest extends TestCase
 
     public function testCompileOnDemand()
     {
-        delete_dir($_ENV['TMP_DIR']);
         $injector = new ScriptInjector(
             $_ENV['TMP_DIR'],
             function () {
@@ -189,5 +188,19 @@ class ScriptInjectorTest extends TestCase
         );
         $car = $injector->getInstance(FakeCar::class);
         $this->assertTrue($car instanceof FakeCar);
+    }
+
+    public function testCompileOnDemandAop()
+    {
+        $injector = new ScriptInjector(
+            $_ENV['TMP_DIR'],
+            function () {
+                return new FakeAopModule;
+            }
+        );
+        /** @var FakeAopInterface $aop */
+        $aop = $injector->getInstance(FakeAopInterface::class);
+        $result = $aop->returnSame(1);
+        $this->assertSame(2, $result);
     }
 }

--- a/tests/ScriptInjectorTest.php
+++ b/tests/ScriptInjectorTest.php
@@ -21,7 +21,6 @@ class ScriptInjectorTest extends TestCase
 
     public function setUp()
     {
-        parent::setUp();
         delete_dir($_ENV['TMP_DIR']);
         $this->injector = new ScriptInjector($_ENV['TMP_DIR']);
     }
@@ -153,6 +152,7 @@ class ScriptInjectorTest extends TestCase
 
     public function testOptional()
     {
+        delete_dir($_ENV['TMP_DIR']);
         /* @var $optional FakeOptional */
         $optional = $this->injector->getInstance(FakeOptional::class);
         $this->assertNull($optional->robot);
@@ -198,6 +198,33 @@ class ScriptInjectorTest extends TestCase
                 return new FakeAopModule;
             }
         );
+        /** @var FakeAopInterface $aop */
+        $aop = $injector->getInstance(FakeAopInterface::class);
+        $result = $aop->returnSame(1);
+        $this->assertSame(2, $result);
+    }
+
+    public function testCompileOnDemandSerialize()
+    {
+        $serialize = \serialize(new ScriptInjector(
+            $_ENV['TMP_DIR'],
+            function () {
+                return new FakeCarModule;
+            }
+        ));
+        $injector = \unserialize($serialize);
+        $car = $injector->getInstance(FakeCar::class);
+        $this->assertTrue($car instanceof FakeCar);
+    }
+
+    public function testCompileOnDemandAopSerialize()
+    {
+        $injector = \unserialize(\serialize(new ScriptInjector(
+            $_ENV['TMP_DIR'],
+            function () {
+                return new FakeAopModule;
+            }
+        )));
         /** @var FakeAopInterface $aop */
         $aop = $injector->getInstance(FakeAopInterface::class);
         $result = $aop->returnSame(1);


### PR DESCRIPTION
1st compil

 * save AOP bindings as `pointcut`
 * save all DI bindings as `module`

On demand compile

 * Compile on demand using cached `module`

See tests

 * testCompileOnDemandSerialize
 * testCompileOnDemandAopSerialize
