### PR TITLE
Parent class binding

### DIFF
--- a/tests/Fake/FakeAbstractClass.php
+++ b/tests/Fake/FakeAbstractClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Ray\Compiler;
+
+abstract class FakeAbstractClass
+{
+}

--- a/tests/Fake/FakeAbstractClassModule.php
+++ b/tests/Fake/FakeAbstractClassModule.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ray\Compiler;
+
+use Ray\Di\AbstractModule;
+
+class FakeAbstractClassModule extends AbstractModule
+{
+    protected function configure() : void
+    {
+        $this->bind(FakeAbstractClass::class)->toProvider(FakeExtendedProvider::class);
+    }
+}

--- a/tests/Fake/FakeExtendedClass.php
+++ b/tests/Fake/FakeExtendedClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Ray\Compiler;
+
+class FakeExtendedClass extends FakeAbstractClass
+{
+}

--- a/tests/Fake/FakeExtendedProvider.php
+++ b/tests/Fake/FakeExtendedProvider.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Ray\Compiler;
+
+use Ray\Di\ProviderInterface;
+
+class FakeExtendedProvider implements ProviderInterface
+{
+    public function get()
+    {
+        return new FakeExtendedClass;
+    }
+}

--- a/tests/ScriptInjectorTest.php
+++ b/tests/ScriptInjectorTest.php
@@ -240,4 +240,16 @@ class ScriptInjectorTest extends TestCase
         $countAfterClear = \count((array) \glob($_ENV['TMP_DIR'] . '/*'));
         $this->assertSame(0, $countAfterClear);
     }
+
+    public function testParentBindingTest() : void
+    {
+        $injector = new ScriptInjector(
+            $_ENV['TMP_DIR'],
+            function () {
+                return new FakeAbstractClassModule;
+            }
+        );
+        $instance = $injector->getInstance(FakeAbstractClass::class);
+        $this->assertInstanceOf(FakeExtendedClass::class, $instance);
+    }
 }


### PR DESCRIPTION
If the no bindings found for the class, try to find its parent class and use it as a binding.

Same with Ray.Di PR #210
https://github.com/ray-di/Ray.Di/pull/210