### PR TITLE
Compile built-in modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Ray\\Compiler\\": ["tests", "tests/Fake"]
+            "Ray\\Compiler\\": ["tests", "tests/Fake"],
+            "Ray\\Di\\": "tests/Fake/Assisted"
         },
         "files": ["tests/deleteFiles.php"]
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="tests/bootstrap.php">
   <coverage processUncoveredFiles="true">
     <include>
@@ -10,4 +10,7 @@
       <directory>tests</directory>
     </testsuite>
   </testsuites>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+  </php>
 </phpunit>

--- a/src/DependencyCode.php
+++ b/src/DependencyCode.php
@@ -18,7 +18,6 @@ use Ray\Di\DependencyInterface;
 use Ray\Di\DependencyProvider;
 use Ray\Di\Instance;
 use Ray\Di\NewInstance;
-use Ray\Di\NullObjectDependency;
 use Ray\Di\SetContextInterface;
 use Ray\Di\SetterMethod;
 use Ray\Di\SetterMethods;
@@ -63,7 +62,7 @@ final class DependencyCode implements SetContextInterface
     /**
      * Return compiled dependency code
      */
-    public function getCode(DependencyInterface $dependency, string $scriptDir = ''): Code
+    public function getCode(DependencyInterface $dependency): Code
     {
         if ($dependency instanceof Dependency) {
             return $this->getDependencyCode($dependency);
@@ -75,10 +74,6 @@ final class DependencyCode implements SetContextInterface
 
         if ($dependency instanceof DependencyProvider) {
             return $this->getProviderCode($dependency);
-        }
-
-        if ($dependency instanceof NullObjectDependency) {
-            return $this->getDependencyCode($dependency->toNull($scriptDir));
         }
 
         throw new DomainException(get_class($dependency));

--- a/src/DiCompiler.php
+++ b/src/DiCompiler.php
@@ -73,7 +73,7 @@ final class DiCompiler implements InjectorInterface
         $container = $this->container->getContainer();
         assert(is_string($scriptDir));
         foreach ($container as $dependencyIndex => $dependency) {
-            $code = $this->dependencyCompiler->getCode($dependency, $scriptDir);
+            $code = $this->dependencyCompiler->getCode($dependency);
             ($this->dependencySaver)($dependencyIndex, $code);
         }
 

--- a/src/MapModule.php
+++ b/src/MapModule.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+use Ray\Di\AbstractModule;
+use Ray\Di\MultiBinding\Map;
+use Ray\Di\MultiBinding\MapProvider;
+
+class MapModule extends AbstractModule
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this->bind(Map::class)->toProvider(MapProvider::class);
+    }
+}

--- a/src/OnDemandCompiler.php
+++ b/src/OnDemandCompiler.php
@@ -48,7 +48,7 @@ final class OnDemandCompiler
     /**
      * Compile dependency on demand
      */
-    public function __invoke(string $dependencyIndex, string $scriptDir): void
+    public function __invoke(string $dependencyIndex): void
     {
         [$class] = explode('-', $dependencyIndex);
         $containerObject = $this->module->getContainer();
@@ -71,7 +71,7 @@ final class OnDemandCompiler
             $dependency->weaveAspects(new Compiler($this->scriptDir), $pointCuts);
         }
 
-        $code = (new DependencyCode($containerObject, $this->injector))->getCode($dependency, $scriptDir);
+        $code = (new DependencyCode($containerObject, $this->injector))->getCode($dependency);
         (new DependencySaver($this->scriptDir))($dependencyIndex, $code);
     }
 

--- a/src/PramReaderModule.php
+++ b/src/PramReaderModule.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+use Koriym\ParamReader\ParamReader;
+use Koriym\ParamReader\ParamReaderInterface;
+use Ray\Di\AbstractModule;
+
+class PramReaderModule extends AbstractModule
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $this->bind(ParamReaderInterface::class)->to(ParamReader::class);
+    }
+}

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -302,7 +302,7 @@ final class ScriptInjector implements InjectorInterface
         }
 
         (new Bind($this->module->getContainer(), ''))->annotatedWith(ScriptDir::class)->toInstance($this->scriptDir); // @phpstan-ignore-line
-        (new OnDemandCompiler($this, $this->scriptDir, $this->module))($dependencyIndex, $this->scriptDir);  // @phpstan-ignore-line
+        (new OnDemandCompiler($this, $this->scriptDir, $this->module))($dependencyIndex);  // @phpstan-ignore-line
     }
 
     private function firstCompile(): void

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -301,13 +301,13 @@ final class ScriptInjector implements InjectorInterface
             $this->firstCompile();
         }
 
-        assert($this->module instanceof AbstractModule);
-        (new Bind($this->module->getContainer(), ''))->annotatedWith(ScriptDir::class)->toInstance($this->scriptDir);
-        (new OnDemandCompiler($this, $this->scriptDir, $this->module))($dependencyIndex, $this->scriptDir);
+        (new Bind($this->module->getContainer(), ''))->annotatedWith(ScriptDir::class)->toInstance($this->scriptDir); // @phpstan-ignore-line
+        (new OnDemandCompiler($this, $this->scriptDir, $this->module))($dependencyIndex, $this->scriptDir);  // @phpstan-ignore-line
     }
 
     private function firstCompile(): void
     {
+        assert($this->module instanceof AbstractModule);
         $compiler = new DiCompiler($this->module, $this->scriptDir);
         $compiler->savePointcuts($this->module->getContainer());
         $this->saveModule();

--- a/tests/AssistedTest.php
+++ b/tests/AssistedTest.php
@@ -24,7 +24,9 @@ class AssistedTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->injector = new Injector(new FakeToBindModule(), __DIR__ . '/tmp');
+        $this->injector = new ScriptInjector(__DIR__ . '/tmp', static function () {
+            return new FakeToBindModule();
+        });
     }
 
     public function testAssisted(): void

--- a/tests/AssistedTest.php
+++ b/tests/AssistedTest.php
@@ -17,6 +17,9 @@ use Ray\Di\FakeToBindModule;
 use Ray\Di\Injector;
 use Ray\Di\InjectorInterface;
 
+/**
+ * @requires PHP 8.0
+ */
 class AssistedTest extends TestCase
 {
     /** @var InjectorInterface */

--- a/tests/AssistedTest.php
+++ b/tests/AssistedTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Ray\Di\Exception\MethodInvocationNotAvailable;
+use Ray\Di\FakeAbstractDb;
+use Ray\Di\FakeAssistedConsumer;
+use Ray\Di\FakeAssistedDbModule;
+use Ray\Di\FakeAssistedDbProvider;
+use Ray\Di\FakeAssistedParamsConsumer;
+use Ray\Di\FakeInstanceBindModule;
+use Ray\Di\FakeRobot;
+use Ray\Di\FakeToBindModule;
+use Ray\Di\Injector;
+use Ray\Di\InjectorInterface;
+
+class AssistedTest extends TestCase
+{
+    /** @var InjectorInterface */
+    private $injector;
+
+    protected function setUp(): void
+    {
+        $this->injector = new Injector(new FakeToBindModule(), __DIR__ . '/tmp');
+    }
+
+    public function testAssisted(): void
+    {
+        $consumer = $this->injector->getInstance(FakeAssistedConsumer::class);
+        /** @var FakeAssistedConsumer $consumer */
+        $assistedDependency = $consumer->assistOne('a', 'b');
+        $expecetd = FakeRobot::class;
+        $this->assertInstanceOf($expecetd, $assistedDependency);
+    }
+
+    public function testAssistedWithName(): void
+    {
+        $this->injector = new Injector(new FakeInstanceBindModule());
+        $consumer = $this->injector->getInstance(FakeAssistedConsumer::class);
+        /** @var FakeAssistedConsumer $consumer */
+        $assistedDependency = $consumer->assistWithName('a7');
+        $expecetd = 1;
+        $this->assertSame($expecetd, $assistedDependency);
+    }
+
+    public function testAssistedAnyWithName(): void
+    {
+        $injector = new Injector(new FakeToBindModule(new FakeInstanceBindModule()));
+        $consumer = $injector->getInstance(FakeAssistedConsumer::class);
+        /** @var FakeAssistedConsumer $consumer */
+        [$assistedDependency1, $assistedDependency2] = $consumer->assistAny();
+        $expected1 = 1;
+        $this->assertSame($expected1, $assistedDependency1);
+        $this->assertInstanceOf(FakeRobot::class, $assistedDependency2);
+    }
+
+    public function testAssistedMethodInvocation(): void
+    {
+        $assistedConsumer = (new Injector(new FakeAssistedDbModule(), __DIR__ . '/tmp'))->getInstance(FakeAssistedParamsConsumer::class);
+        /** @var FakeAssistedParamsConsumer $assistedConsumer */
+        [$id, $db] = $assistedConsumer->getUser(1);
+        /** @var FakeAbstractDb $db */
+        $this->assertSame(1, $id);
+        $this->assertSame(1, $db->dbId);
+    }
+
+    public function testAssistedMethodInvocationNotAvailable(): void
+    {
+        $this->expectException(MethodInvocationNotAvailable::class);
+        $assistedDbProvider = (new Injector(new FakeAssistedDbModule()))->getInstance(FakeAssistedDbProvider::class);
+        /** @var FakeAssistedDbProvider $assistedDbProvider */
+        $assistedDbProvider->get();
+    }
+
+    public function testAssistedCustomeInject(): void
+    {
+        $assistedConsumer = (new Injector(new FakeAssistedDbModule(), __DIR__ . '/tmp'))->getInstance(FakeAssistedParamsConsumer::class);
+        /** @var FakeAssistedParamsConsumer $assistedConsumer */
+        [$id, $db] = $assistedConsumer->getUser(1);
+        /** @var FakeAbstractDb $db */
+        $this->assertSame(1, $id);
+    }
+}

--- a/tests/Fake/Assisted/Annotation/FakeInjectOne.php
+++ b/tests/Fake/Assisted/Annotation/FakeInjectOne.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di\Annotation;
+
+use Attribute;
+use Ray\Di\Di\InjectInterface;
+use Ray\Di\Di\Qualifier;
+
+#[Attribute, Qualifier]
+final class FakeInjectOne implements InjectInterface
+{
+    public function isOptional()
+    {
+        return false;
+    }
+}

--- a/tests/Fake/Assisted/FakeAbstractDb.php
+++ b/tests/Fake/Assisted/FakeAbstractDb.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeAbstractDb
+{
+    public $dbId;
+
+    public function __construct($id)
+    {
+        $this->dbId = $id;
+    }
+}

--- a/tests/Fake/Assisted/FakeAssistedConsumer.php
+++ b/tests/Fake/Assisted/FakeAssistedConsumer.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Ray\Di\Di\Assisted;
+use Ray\Di\Di\Named;
+
+class FakeAssistedConsumer
+{
+    /**
+     * @return FakeRobotInterface|null
+     *
+     * @Assisted({"robot"})
+     */
+    public function assistOne($a, $b, ?FakeRobotInterface $robot = null)
+    {
+        unset($a, $b);
+
+        return $robot;
+    }
+
+    /**
+     * @Assisted({"var1"})
+     * @Named("var1=one")
+     */
+    public function assistWithName($a, $var1 = null)
+    {
+        unset($a);
+
+        return $var1;
+    }
+
+    /**
+     * @return (FakeRobotInterface|mixed|null)[]
+     * @psalm-return array{0: mixed, 1: FakeRobotInterface|null}
+     *
+     * @Assisted({"var2", "robot"})
+     * @Named("var2=one")
+     */
+    public function assistAny($var2 = null, ?FakeRobotInterface $robot = null)
+    {
+        return [$var2, $robot];
+    }
+}

--- a/tests/Fake/Assisted/FakeAssistedDb.php
+++ b/tests/Fake/Assisted/FakeAssistedDb.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeAssistedDb extends FakeAbstractDb
+{
+    public $dbId;
+}

--- a/tests/Fake/Assisted/FakeAssistedDbModule.php
+++ b/tests/Fake/Assisted/FakeAssistedDbModule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeAssistedDbModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->bind(FakeAbstractDb::class)->toProvider(FakeAssistedDbProvider::class);
+    }
+}

--- a/tests/Fake/Assisted/FakeAssistedDbProvider.php
+++ b/tests/Fake/Assisted/FakeAssistedDbProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeAssistedDbProvider implements ProviderInterface
+{
+    /** @var MethodInvocationProvider */
+    private $invocationProvider;
+
+    public function __construct(MethodInvocationProvider $invocationProvider)
+    {
+        $this->invocationProvider = $invocationProvider;
+    }
+
+    public function get()
+    {
+        $parameters = $this->invocationProvider->get()->getArguments()->getArrayCopy();
+        [$id] = $parameters;
+
+        return new FakeAssistedDb($id);
+    }
+}

--- a/tests/Fake/Assisted/FakeAssistedInjectConsumer.php
+++ b/tests/Fake/Assisted/FakeAssistedInjectConsumer.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Ray\Di\Annotation\FakeInjectOne;
+use Ray\Di\Di\Assisted;
+use Ray\Di\Di\Inject;
+use Ray\Di\Di\Named;
+
+class FakeAssistedInjectConsumer
+{
+    public function assistOne($a, $b, #[Assisted] ?\Ray\Compiler\FakeRobotInterface $robot = null): ?\Ray\Compiler\FakeRobotInterface
+    {
+        unset($a, $b);
+
+        return $robot;
+    }
+
+    public function assistWithName($a, #[Assisted, Named('one')] $var1 = null)
+    {
+        unset($a);
+
+        return $var1;
+    }
+
+    /**
+     * @return (FakeRobotInterface|mixed|null)[]
+     * @psalm-return array{0: mixed, 1: FakeRobotInterface|null}
+     */
+    public function assistAny(#[Assisted, Named('one')] $var2 = null, #[Inject] ?FakeRobotInterface $robot = null)
+    {
+        return [$var2, $robot];
+    }
+
+    public function assistCustomeAssistedInject(#[FakeInjectOne] int $one = 0): int
+    {
+        return $one;
+    }
+}

--- a/tests/Fake/Assisted/FakeAssistedInjectDb.php
+++ b/tests/Fake/Assisted/FakeAssistedInjectDb.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Ray\Di\Di\Assisted;
+use Ray\Di\Di\Inject;
+
+class FakeAssistedInjectDb
+{
+    /**
+     * @return array [int, FakeAbstractDb]
+     */
+    public function getUser($id, #[Inject] ?FakeAbstractDb $db = null)
+    {
+        return [$id, $db];
+    }
+}

--- a/tests/Fake/Assisted/FakeAssistedParamsConsumer.php
+++ b/tests/Fake/Assisted/FakeAssistedParamsConsumer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Ray\Di\Di\Assisted;
+
+class FakeAssistedParamsConsumer
+{
+    /**
+     * @return array [int, FakeAbstractDb]
+     *
+     * @Assisted({"db"})
+     */
+    public function getUser($id, ?FakeAbstractDb $db = null)
+    {
+        return [$id, $db];
+    }
+}

--- a/tests/Fake/Assisted/FakeInstanceBindModule.php
+++ b/tests/Fake/Assisted/FakeInstanceBindModule.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+use Ray\Di\Annotation\FakeInjectOne;
+
+class FakeInstanceBindModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->bind('')->annotatedWith('one')->toInstance(1);
+        $this->bind('')->annotatedWith(FakeInjectOne::class)->toInstance(1);
+    }
+}

--- a/tests/Fake/Assisted/FakeRobot.php
+++ b/tests/Fake/Assisted/FakeRobot.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeRobot implements FakeRobotInterface
+{
+}

--- a/tests/Fake/Assisted/FakeRobotInterface.php
+++ b/tests/Fake/Assisted/FakeRobotInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+interface FakeRobotInterface
+{
+}

--- a/tests/Fake/Assisted/FakeToBindModule.php
+++ b/tests/Fake/Assisted/FakeToBindModule.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Di;
+
+class FakeToBindModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->bind(FakeRobotInterface::class)->to(FakeRobot::class);
+    }
+}

--- a/tests/Fake/MultiBindings/FakeEngine.php
+++ b/tests/Fake/MultiBindings/FakeEngine.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\MultiBindings;
+
+class FakeEngine implements FakeEngineInterface
+{
+    public function foo()
+    {
+    }
+}

--- a/tests/Fake/MultiBindings/FakeEngine2.php
+++ b/tests/Fake/MultiBindings/FakeEngine2.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\MultiBindings;
+
+class FakeEngine2 implements FakeEngineInterface
+{
+    public function foo()
+    {
+    }
+}

--- a/tests/Fake/MultiBindings/FakeEngine3.php
+++ b/tests/Fake/MultiBindings/FakeEngine3.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\MultiBindings;
+
+class FakeEngine3 implements FakeEngineInterface
+{
+    public function foo()
+    {
+    }
+}

--- a/tests/Fake/MultiBindings/FakeEngineInterface.php
+++ b/tests/Fake/MultiBindings/FakeEngineInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\MultiBindings;
+
+interface FakeEngineInterface
+{
+    public function foo();
+}

--- a/tests/Fake/MultiBindings/FakeMultiBindingAnnotation.php
+++ b/tests/Fake/MultiBindings/FakeMultiBindingAnnotation.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\MultiBindings;
+
+
+use Ray\Di\Di\Set;
+use Ray\Di\MultiBinding\Map;
+
+final class FakeMultiBindingAnnotation
+{
+    /**
+     * @var Map<FakeEngineInterface>
+     * @Set(FakeEngineInterface::class)
+     */
+    public $engines;
+
+    /**
+     * @var Map<FakeRobotInterface>
+     * @Set(FakeRobotInterface::class)
+     */
+    public $robots;
+
+    public function __construct(
+        Map $engines,
+        Map $robots
+    ){
+        $this->engines = $engines;
+        $this->robots = $robots;
+    }
+}

--- a/tests/Fake/MultiBindings/FakeMultiBindingConsumer.php
+++ b/tests/Fake/MultiBindings/FakeMultiBindingConsumer.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\MultiBindings;
+
+
+use Ray\Di\Di\Set;
+use Ray\Di\MultiBinding\Map;
+
+final class FakeMultiBindingConsumer
+{
+    /**
+     * @param Map<FakeEngineInterface> $engines
+     * @param Map<FakeRobotInterface> $robots
+     */
+    public function __construct(
+        #[Set(FakeEngineInterface::class)] public Map $engines,
+        #[Set(FakeRobotInterface::class)] public Map $robots
+    ){}
+
+    public function testValid(): void
+    {
+        $f = $this->engines['one'];
+        // cause no error in psalm
+        $f->foo();
+    }
+
+    /**
+     * Test generic
+     *
+     * This tests generic expression of Map<FakeEngineInterface>
+     * Not called from any place. Created to confirm "@psalm-suppress" works with psalm
+     *
+     * @psalm-suppress UndefinedInterfaceMethod
+     */
+    public function testInvalid(): void
+    {
+        $f = $this->engines['one'];
+        // cause error in psalm
+        $f->warnUndefinedInterfaceMethod();
+    }
+}

--- a/tests/Fake/MultiBindings/FakeMultiBindingsModule.php
+++ b/tests/Fake/MultiBindings/FakeMultiBindingsModule.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\Fake\MultiBindings;
+
+
+use Ray\Compiler\MultiBindings\FakeEngine;
+use Ray\Compiler\MultiBindings\FakeEngine2;
+use Ray\Compiler\MultiBindings\FakeEngine3;
+use Ray\Compiler\MultiBindings\FakeEngineInterface;
+use Ray\Compiler\MultiBindings\FakeRobot;
+use Ray\Compiler\MultiBindings\FakeRobotInterface;
+use Ray\Compiler\MultiBindings\FakeRobotProvider;
+use Ray\Di\AbstractModule;
+use Ray\Di\MultiBinder;
+
+final class FakeMultiBindingsModule extends AbstractModule
+{
+    protected function configure(): void
+    {
+        $engineBinder = MultiBinder::newInstance($this, FakeEngineInterface::class);
+        $engineBinder->addBinding('one')->to(FakeEngine::class);
+        $engineBinder->addBinding('two')->to(FakeEngine2::class);
+        $engineBinder->addBinding()->to(FakeEngine3::class);
+        $robotBinder = MultiBinder::newInstance($this, FakeRobotInterface::class);
+        $robotBinder->addBinding('to')->to(FakeRobot::class);
+        $robotBinder->addBinding('provider')->toProvider(FakeRobotProvider::class);
+        $robotBinder->addBinding('instance')->toInstance(new FakeRobot());
+    }
+}

--- a/tests/Fake/MultiBindings/FakeRobot.php
+++ b/tests/Fake/MultiBindings/FakeRobot.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\MultiBindings;
+
+class FakeRobot implements FakeRobotInterface
+{
+}

--- a/tests/Fake/MultiBindings/FakeRobotInterface.php
+++ b/tests/Fake/MultiBindings/FakeRobotInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\MultiBindings;
+
+interface FakeRobotInterface
+{
+}

--- a/tests/Fake/MultiBindings/FakeRobotProvider.php
+++ b/tests/Fake/MultiBindings/FakeRobotProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\MultiBindings;
+
+use Ray\Di\ProviderInterface;
+
+class FakeRobotProvider implements ProviderInterface
+{
+    public function get()
+    {
+        return new FakeRobot();
+    }
+}

--- a/tests/Fake/MultiBindings/FakeSetNotFoundWithMap.php
+++ b/tests/Fake/MultiBindings/FakeSetNotFoundWithMap.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\MultiBindings;
+
+
+use Ray\Di\Di\Set;
+use Ray\Di\MultiBinding\Map;
+
+final class FakeSetNotFoundWithMap
+{
+    /**
+     * @var Map<FakeEngineInterface>
+     */
+    public $engines;
+
+    /**
+     * This property should Set annotated for setProviderButNotSetFound method.
+     * SetNotFound exception will be thrown.
+     */
+    public $engineProvider;
+
+    public function __construct(
+        Map $engines
+    ){
+        $this->engines = $engines;
+    }
+}

--- a/tests/Fake/MultiBindings/FakeSetNotFoundWithProvider.php
+++ b/tests/Fake/MultiBindings/FakeSetNotFoundWithProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\MultiBindings;
+
+
+use Ray\Di\Di\Set;
+use Ray\Di\MultiBinding\Map;
+use Ray\Di\ProviderInterface;
+
+final class FakeSetNotFoundWithProvider
+{
+    /**
+     * This property should Set annotated for setProviderButNotSetFound method.
+     * SetNotFound exception will be thrown.
+     */
+    public $engineProvider;
+
+    public function __construct(
+        ProviderInterface $engineProvider
+    ){
+        $this->$engineProvider = $engineProvider;
+    }
+}

--- a/tests/MultiBindingTest.php
+++ b/tests/MultiBindingTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+use LogicException;
+use PHPUnit\Framework\TestCase;
+use Ray\Compiler\Fake\MultiBindings\FakeMultiBindingsModule;
+use Ray\Compiler\MultiBindings\FakeEngine;
+use Ray\Compiler\MultiBindings\FakeEngine2;
+use Ray\Compiler\MultiBindings\FakeEngineInterface;
+use Ray\Compiler\MultiBindings\FakeMultiBindingAnnotation;
+use Ray\Compiler\MultiBindings\FakeMultiBindingConsumer;
+use Ray\Compiler\MultiBindings\FakeRobot;
+use Ray\Compiler\MultiBindings\FakeRobotInterface;
+use Ray\Compiler\MultiBindings\FakeSetNotFoundWithMap;
+use Ray\Compiler\MultiBindings\FakeSetNotFoundWithProvider;
+use Ray\Di\AbstractModule;
+use Ray\Di\Exception\SetNotFound;
+use Ray\Di\InjectorInterface;
+use Ray\Di\MultiBinder;
+use Ray\Di\MultiBinding\Map;
+use Ray\Di\MultiBinding\MultiBindings;
+use Ray\Di\NullModule;
+
+use function count;
+
+/**
+ * @requires PHP 8.0
+ */
+class MultiBindingTest extends TestCase
+{
+    /** @var InjectorInterface */
+    private $injector;
+
+    protected function setUp(): void
+    {
+        $this->injector = new ScriptInjector(__DIR__ . '/tmp', static function () {
+            return new FakeMultiBindingsModule();
+        });
+    }
+
+    public function testInjectMap(): Map
+    {
+        /** @var FakeMultiBindingConsumer $consumer */
+        $consumer = $this->injector->getInstance(FakeMultiBindingConsumer::class);
+        $this->assertInstanceOf(Map::class, $consumer->engines);
+
+        return $consumer->engines;
+    }
+
+    /**
+     * @depends testInjectMap
+     */
+    public function testMapInstance(Map $map): void
+    {
+        $this->assertInstanceOf(FakeEngine::class, $map['one']);
+        $this->assertInstanceOf(FakeEngine2::class, $map['two']);
+    }
+
+    /**
+     * @depends testInjectMap
+     */
+    public function testMapIteration(Map $map): void
+    {
+        $this->assertContainsOnlyInstancesOf(FakeEngineInterface::class, $map);
+
+        $this->assertSame(3, count($map));
+    }
+
+    /**
+     * @depends testInjectMap
+     */
+    public function testIsSet(Map $map): void
+    {
+        $this->assertTrue(isset($map['one']));
+        $this->assertTrue(isset($map['two']));
+    }
+
+    /**
+     * @depends testInjectMap
+     */
+    public function testOffsetSet(Map $map): void
+    {
+        $this->expectException(LogicException::class);
+        $map['one'] = 1;
+    }
+
+    /**
+     * @depends testInjectMap
+     */
+    public function testOffsetUnset(Map $map): void
+    {
+        $this->expectException(LogicException::class);
+        unset($map['one']);
+    }
+
+    public function testAnotherBinder(): void
+    {
+        /** @var FakeMultiBindingConsumer $consumer */
+        $consumer = $this->injector->getInstance(FakeMultiBindingConsumer::class);
+        $this->assertInstanceOf(Map::class, $consumer->robots);
+        $this->assertContainsOnlyInstancesOf(FakeRobot::class, $consumer->robots);
+        $this->assertSame(3, count($consumer->robots));
+    }
+
+    public function testMultipileModule(): void
+    {
+        $module = new NullModule();
+        $binder = MultiBinder::newInstance($module, FakeEngineInterface::class);
+        $binder->addBinding('one')->to(FakeEngine::class);
+        $binder->addBinding('two')->to(FakeEngine2::class);
+        $module->install(new class extends AbstractModule {
+            protected function configure()
+            {
+                $binder = MultiBinder::newInstance($this, FakeEngineInterface::class);
+                $binder->addBinding('three')->to(FakeEngine::class);
+                $binder->addBinding('four')->to(FakeEngine::class);
+            }
+        });
+        /** @var MultiBindings $multiBindings */
+        $multiBindings = $module->getContainer()->getInstance(MultiBindings::class);
+        $this->assertArrayHasKey('one', (array) $multiBindings[FakeEngineInterface::class]);
+        $this->assertArrayHasKey('two', (array) $multiBindings[FakeEngineInterface::class]);
+        $this->assertArrayHasKey('three', (array) $multiBindings[FakeEngineInterface::class]);
+        $this->assertArrayHasKey('four', (array) $multiBindings[FakeEngineInterface::class]);
+    }
+
+    public function testAnnotation(): void
+    {
+        /** @var FakeMultiBindingAnnotation $fake */
+        $fake = $this->injector->getInstance(FakeMultiBindingAnnotation::class);
+        $this->assertContainsOnlyInstancesOf(FakeEngineInterface::class, $fake->engines);
+        $this->assertSame(3, count($fake->engines));
+        $this->assertContainsOnlyInstancesOf(FakeRobotInterface::class, $fake->robots);
+        $this->assertSame(3, count($fake->robots));
+    }
+
+    public function testSetNotFoundInMap(): void
+    {
+        $this->expectException(SetNotFound::class);
+        $this->injector->getInstance(FakeSetNotFoundWithMap::class);
+    }
+
+    public function testSetNotFoundInProvider(): void
+    {
+        $this->expectException(SetNotFound::class);
+        $this->injector->getInstance(FakeSetNotFoundWithProvider::class);
+    }
+}


### PR DESCRIPTION
Closes #85 

詳細

* `ParamReaderInterface`は`MultiBindings`を依存していますが、`MultiBindings`はマルチバインドしないとモジュールに登録されず、`ParamReaderInterface`のコンパイル時に`Map`のウnboundの例外が出てしまいます。なのでマルチバインドした時だけインストールしています。

* Ray.Di側での`MultiBindingsModule`モジュールが`ParamReaderInterface`と`Map`を同時にしてしまっているため（正しくない）、Ray.Compilerでは`MultiBindingsModule`を再利用しないで、`PramReaderModule`と`MapModule`に分割しています。

* 上記解説： `MultiBindings`の束縛は モジュール内で`MultiBindings`呼び出すことによって初めて束縛され、その後に束縛が追加されてきいます。https://github.com/ray-di/Ray.Di/blob/2.x/src/di/MultiBinder.php#L33 つまりマルチバインド束縛を行わないと `MultiBindings`の束縛がなく、そのため、それに依存する`MapProvider`の束縛でエラーが出てしまいます。解決として`MultiBindings`束縛がある時だけ`MapProvider`の束縛を行いコンパイルするようにしました。（依存が遅延解決されるRay.Diではこの問題が起こりませんでした）

https://github.com/ray-di/Ray.Di/blob/2.x/src/di/MultiBinding/MapProvider.php#L30