### PR TITLE
Deep copy the container

### DIFF
--- a/tests/CachedFactoryTest.php
+++ b/tests/CachedFactoryTest.php
@@ -17,7 +17,7 @@ class CachedFactoryTest extends TestCase
     {
         $injector1 = $this->getInjector('dev');
         $injector2 = $this->getInjector('dev');
-        $this->assertSame(spl_object_hash($injector1), spl_object_hash($injector2));
+        $this->assertNotSame(spl_object_hash($injector1), spl_object_hash($injector2));
     }
 
     public function testInstanceCachedInFileCache(): void
@@ -26,7 +26,7 @@ class CachedFactoryTest extends TestCase
         $this->assertFalse(DevCache::$wasHit);
         $injector2 = $this->getInjector('prod');
         $this->assertFalse(DevCache::$wasHit);
-        $this->assertSame(spl_object_hash($injector1), spl_object_hash($injector2));
+        $this->assertNotSame(spl_object_hash($injector1), spl_object_hash($injector2));
         $injector2->getInstance(FakeRobotInterface::class);
     }
 

--- a/tests/ContextInjectorTest.php
+++ b/tests/ContextInjectorTest.php
@@ -7,7 +7,9 @@ namespace Ray\Compiler;
 use Doctrine\Common\Cache\CacheProvider;
 use PHPUnit\Framework\TestCase;
 use Ray\Compiler\Deep\FakeDeep;
+use Ray\Compiler\Deep\FakeDemand;
 use Ray\Compiler\Deep\FakeInjectorContext;
+use Ray\Compiler\Deep\FakeScriptInjectorContext;
 use Ray\Di\AbstractModule;
 use Ray\Di\InjectorInterface;
 use Ray\Di\NullCache;
@@ -47,9 +49,22 @@ class ContextInjectorTest extends TestCase
         $this->assertInstanceOf(InjectorInterface::class, $injector);
     }
 
-    public function testContainerIsResetWhenTheInjectorIsRetrieved(): void
+    /**
+     * @return array<array<AbstractInjectorContext>>
+     */
+    public function contextProvider(): array
     {
-        $context = new FakeInjectorContext(__DIR__ . '/tmp');
+        return [
+            [new FakeInjectorContext(__DIR__ . '/tmp')],
+            [new FakeScriptInjectorContext(__DIR__ . '/tmp')],
+        ];
+    }
+
+    /**
+     * @dataProvider contextProvider
+     */
+    public function testContainerIsResetWhenTheInjectorIsRetrieved(AbstractInjectorContext $context): void
+    {
         $injector = ContextInjector::getInstance($context);
         $deep = $injector->getInstance(FakeDeep::class);
         assert($deep instanceof FakeDeep);
@@ -61,5 +76,7 @@ class ContextInjectorTest extends TestCase
         $deep2 = $injector->getInstance(FakeDeep::class);
         assert($deep2 instanceof FakeDeep);
         $this->assertFalse($deep2->dep->changed);
+        $demand = $injector->getInstance(FakeDemand::class);
+        $this->assertInstanceOf(FakeDemand::class, $demand);
     }
 }

--- a/tests/ContextInjectorTest.php
+++ b/tests/ContextInjectorTest.php
@@ -6,9 +6,13 @@ namespace Ray\Compiler;
 
 use Doctrine\Common\Cache\CacheProvider;
 use PHPUnit\Framework\TestCase;
+use Ray\Compiler\Deep\FakeDeep;
+use Ray\Compiler\Deep\FakeInjectorContext;
 use Ray\Di\AbstractModule;
 use Ray\Di\InjectorInterface;
 use Ray\Di\NullCache;
+
+use function assert;
 
 class ContextInjectorTest extends TestCase
 {
@@ -41,5 +45,21 @@ class ContextInjectorTest extends TestCase
         };
         $injector = ContextInjector::getInstance($compileContext);
         $this->assertInstanceOf(InjectorInterface::class, $injector);
+    }
+
+    public function testContainerIsResetWhenTheInjectorIsRetrieved(): void
+    {
+        $context = new FakeInjectorContext(__DIR__ . '/tmp');
+        $injector = ContextInjector::getInstance($context);
+        $deep = $injector->getInstance(FakeDeep::class);
+        assert($deep instanceof FakeDeep);
+        $deep->dep->changed = true;
+        $deep1 = $injector->getInstance(FakeDeep::class);
+        assert($deep1 instanceof FakeDeep);
+        $this->assertTrue($deep->dep->changed);
+        $injector = ContextInjector::getInstance($context);
+        $deep2 = $injector->getInstance(FakeDeep::class);
+        assert($deep2 instanceof FakeDeep);
+        $this->assertFalse($deep2->dep->changed);
     }
 }

--- a/tests/Fake/Deep/FakeDeep.php
+++ b/tests/Fake/Deep/FakeDeep.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\Deep;
+
+
+final class FakeDeep
+{
+    public $dep;
+    public function __construct(
+        FakeDep $dep
+    )
+    {
+        $this->dep = $dep;
+    }
+}

--- a/tests/Fake/Deep/FakeDemand.php
+++ b/tests/Fake/Deep/FakeDemand.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\Deep;
+
+
+final class FakeDemand
+{
+    public $dep;
+    public function __construct(
+        FakeDep $dep
+    )
+    {
+        $this->dep = $dep;
+    }
+}

--- a/tests/Fake/Deep/FakeDep.php
+++ b/tests/Fake/Deep/FakeDep.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\Deep;
+
+
+final class FakeDep
+{
+    public $changed = false;
+}

--- a/tests/Fake/Deep/FakeDepModule.php
+++ b/tests/Fake/Deep/FakeDepModule.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\Deep;
+
+use Ray\Di\AbstractModule;
+use Ray\Di\Scope;
+
+final class FakeDepModule extends AbstractModule
+{
+    protected function configure()
+    {
+        $this->bind(FakeDep::class)->in(Scope::SINGLETON);
+    }
+}

--- a/tests/Fake/Deep/FakeInjectorContext.php
+++ b/tests/Fake/Deep/FakeInjectorContext.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\Deep;
+
+
+use Doctrine\Common\Cache\CacheProvider;
+use Ray\Compiler\AbstractInjectorContext;
+use Ray\Di\AbstractModule;
+use Ray\Di\NullCache;
+use Ray\Di\Scope;
+
+final class FakeInjectorContext extends AbstractInjectorContext
+{
+    public function getModule(): AbstractModule
+    {
+        return new class extends AbstractModule
+        {
+            protected function configure()
+            {
+               $this->bind(FakeDep::class)->in(Scope::SINGLETON);
+            }
+        };
+    }
+
+    public function getCache(): CacheProvider
+    {
+       return new NullCache();
+    }
+}

--- a/tests/Fake/Deep/FakeScriptInjectorContext.php
+++ b/tests/Fake/Deep/FakeScriptInjectorContext.php
@@ -6,12 +6,15 @@ namespace Ray\Compiler\Deep;
 
 
 use Doctrine\Common\Cache\CacheProvider;
+use Doctrine\Common\Cache\FilesystemCache;
 use Ray\Compiler\AbstractInjectorContext;
+use Ray\Compiler\Annotation\Compile;
+use Ray\Compiler\DiCompileModule;
 use Ray\Di\AbstractModule;
 use Ray\Di\NullCache;
 use Ray\Di\Scope;
 
-final class FakeInjectorContext extends AbstractInjectorContext
+final class FakeScriptInjectorContext extends AbstractInjectorContext
 {
     public function getModule(): AbstractModule
     {
@@ -20,6 +23,6 @@ final class FakeInjectorContext extends AbstractInjectorContext
 
     public function getCache(): CacheProvider
     {
-       return new NullCache();
+       return new FilesystemCache('/tmp');
     }
 }


### PR DESCRIPTION
Closes #88 

`CachedInjectorFactory::getInstance()`およびこれを利用する`ContextInjector::getInstance()`でインジェクターを取得した時にコンテナを状態変化のないフレッシュな状態にします。