### PR TITLE
Failed to compile context binding when context has type

### DIFF
--- a/src/DependencyCode.php
+++ b/src/DependencyCode.php
@@ -23,6 +23,7 @@ use Ray\Di\SetterMethod;
 use Ray\Di\SetterMethods;
 
 use function get_class;
+use function is_a;
 
 final class DependencyCode implements SetContextInterface
 {
@@ -138,7 +139,10 @@ final class DependencyCode implements SetContextInterface
         $dependency = $prop($provider, 'dependency');
         $node = $this->getFactoryNode($dependency);
         $provider->setContext($this);
-        if ($this->context) {
+        /** @var NewInstance $class */
+        $class = $prop($dependency, 'newInstance');
+        $classString = (string) $class;
+        if (is_a($classString, SetContextInterface::class, true)) {
             $node[] = $this->getSetContextCode($this->context); // $instance->setContext($this->context);
         }
 

--- a/tests/ContextBindingTest.php
+++ b/tests/ContextBindingTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+use PHPUnit\Framework\TestCase;
+
+final class ContextBindingTest extends TestCase
+{
+    public function setUp(): void
+    {
+        deleteFiles(__DIR__ . '/tmp');
+    }
+
+    /** @requires PHP >= 7.4 */
+    public function testContextBindingWhenContextIsEmptyAndPropertyHasType(): void
+    {
+        $injector = new ScriptInjector(__DIR__ . '/tmp', static function () {
+            return new FakeDependContextualRobotModule('');
+        });
+
+        $instance = $injector->getInstance(FakeRobotInterface::class);
+        $this->assertInstanceOf(FakeRobotInterface::class, $instance);
+    }
+}

--- a/tests/ContextBindingTest.php
+++ b/tests/ContextBindingTest.php
@@ -23,4 +23,15 @@ final class ContextBindingTest extends TestCase
         $instance = $injector->getInstance(FakeRobotInterface::class);
         $this->assertInstanceOf(FakeRobotInterface::class, $instance);
     }
+
+    /** @requires PHP >= 7.4 */
+    public function testContextBindingWhenContextIsEmpty(): void
+    {
+        $injector = new ScriptInjector(__DIR__ . '/tmp', static function () {
+            return new FakeContextualModule('');
+        });
+
+        $instance = $injector->getInstance(FakeRobotInterface::class);
+        $this->assertInstanceOf(FakeRobotInterface::class, $instance);
+    }
 }

--- a/tests/Fake/FakeContextualRobot.php
+++ b/tests/Fake/FakeContextualRobot.php
@@ -8,7 +8,7 @@ class FakeContextualRobot implements FakeRobotInterface
 {
     public $context;
 
-    public function __construct($context)
+    public function __construct(string $context)
     {
         $this->context = $context;
     }

--- a/tests/Fake/FakeDependContextualRobotModule.php
+++ b/tests/Fake/FakeDependContextualRobotModule.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+use Ray\Di\AbstractModule;
+
+class FakeDependContextualRobotModule extends AbstractModule
+{
+
+    /** @var string */
+    private $context;
+
+    public function __construct(string $context, ?AbstractModule $module = null)
+    {
+        $this->context = $context;
+        parent::__construct($module);
+    }
+
+    protected function configure()
+    {
+        $this->bind(FakeRobotInterface::class)->toProvider(FakeTypedPropertyContextualProvider::class, $this->context);
+    }
+}

--- a/tests/Fake/FakeTypedPropertyContextualProvider.php
+++ b/tests/Fake/FakeTypedPropertyContextualProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+use Ray\Di\ProviderInterface;
+use Ray\Di\SetContextInterface;
+
+class FakeTypedPropertyContextualProvider implements ProviderInterface, SetContextInterface
+{
+    private string $context;
+
+    /**
+     * @inheritDoc
+     */
+    public function setContext($context)
+    {
+        $this->context = $context;
+    }
+
+    public function get()
+    {
+        return new FakeContextualRobot($this->context);
+    }
+}


### PR DESCRIPTION
Existing generated code

```php
<?php

namespace Ray\Di\Compiler;

$instance = new \Ray\Compiler\FakeTypedPropertyContextualProvider();
$isSingleton = false;
return $instance->get();
```

New generated code.

```php
<?php

namespace Ray\Di\Compiler;

$instance = new \Ray\Compiler\FakeTypedPropertyContextualProvider();
$instance->setContext('');
$isSingleton = false;
return $instance->get();
```