### PR TITLE
Null binding objects are not created per context

### DIFF
--- a/tests/ContextInjectorTest.php
+++ b/tests/ContextInjectorTest.php
@@ -28,10 +28,23 @@ class ContextInjectorTest extends TestCase
 
     public function testGetCompileInjector(): void
     {
-        $injector = ContextInjector::getInstance(new FakeProdContext(__DIR__ . '/tmp/base'));
+        $injector = ContextInjector::getInstance(new FakeProdContext(__DIR__ . '/tmp/prod'));
         $this->assertInstanceOf(CompileInjector::class, $injector);
         $robot = $injector->getInstance(FakeRobotInterface::class);
         $this->assertInstanceOf(FakeRobotInterface::class, $robot);
+
+        $this->assertFileExists(__DIR__ . '/tmp/prod/Ray_Compiler_FakeAopInterfaceNull.php');
+    }
+
+    /** @depends testGetCompileInjector */
+    public function testOtherContext(): void
+    {
+        $injector = ContextInjector::getInstance(new FakeStgContext(__DIR__ . '/tmp/stg'));
+        $this->assertInstanceOf(CompileInjector::class, $injector);
+        $robot = $injector->getInstance(FakeRobotInterface::class);
+        $this->assertInstanceOf(FakeRobotInterface::class, $robot);
+
+        $this->assertFileExists(__DIR__ . '/tmp/stg/Ray_Compiler_FakeAopInterfaceNull.php');
     }
 
     /**

--- a/tests/Fake/FakeStgContext.php
+++ b/tests/Fake/FakeStgContext.php
@@ -8,7 +8,7 @@ use Doctrine\Common\Cache\CacheProvider;
 use Ray\Di\AbstractModule;
 use Ray\Di\NullCache;
 
-final class FakeProdContext extends AbstractInjectorContext
+final class FakeStgContext extends AbstractInjectorContext
 {
     function __invoke(): AbstractModule
     {


### PR DESCRIPTION
Compile result of `testGetCompileInjector`

```
$ tree prod                                                               
prod
├── -Ray_Compiler_Annotation_Compile.php
├── -Ray_Di_Annotation_ScriptDir.php
├── Doctrine_Common_Annotations_Reader-.php
├── Koriym_ParamReader_ParamReaderInterface-.php
├── Ray_Aop_MethodInvocation-.php
├── Ray_Aop_NullInterceptor-.php
├── Ray_Compiler_FakeAopInterface-.php
├── Ray_Compiler_FakeAopInterfaceNull.php
├── Ray_Compiler_FakeAopInterfaceNull_806959914.php
├── Ray_Compiler_FakeRobotInterface-.php
├── Ray_Di_AssistedInjectInterceptor-.php
├── Ray_Di_AssistedInterceptor-.php
├── Ray_Di_InjectorInterface-.php
├── Ray_Di_MethodInvocationProvider-.php
└── Ray_Di_ProviderInterface-.php

1 directory, 15 files
```

Compile result of `testOtherContext`

```
$ tree stg                                           
stg
├── -Ray_Compiler_Annotation_Compile.php
├── -Ray_Di_Annotation_ScriptDir.php
├── Doctrine_Common_Annotations_Reader-.php
├── Koriym_ParamReader_ParamReaderInterface-.php
├── Ray_Aop_MethodInvocation-.php
├── Ray_Aop_NullInterceptor-.php
├── Ray_Compiler_FakeAopInterface-.php
├── Ray_Compiler_FakeAopInterfaceNull_4184416832.php
├── Ray_Compiler_FakeRobotInterface-.php
├── Ray_Di_AssistedInjectInterceptor-.php
├── Ray_Di_AssistedInterceptor-.php
├── Ray_Di_InjectorInterface-.php
├── Ray_Di_MethodInvocationProvider-.php
└── Ray_Di_ProviderInterface-.php

1 directory, 14 files
```

when `testOtherContext`,  `Ray_Compiler_FakeAopInterfaceNull.php` is not generated.