### PR TITLE
Add getOverrideInstance method

### DIFF
--- a/src/CachedInjectorFactory.php
+++ b/src/CachedInjectorFactory.php
@@ -58,8 +58,25 @@ final class CachedInjectorFactory
      * @param callable(): AbstractModule $modules
      * @param array<class-string>        $savedSingletons
      */
-    private static function getInjector(callable $modules, string $scriptDir, array $savedSingletons): InjectorInterface
+    public static function getOverrideInstance(
+        string $scriptDir,
+        callable $modules,
+        AbstractModule $overrideModule,
+        array $savedSingletons = []
+    ): InjectorInterface {
+        return self::getInjector($modules, $scriptDir, $savedSingletons, $overrideModule);
+    }
+
+    /**
+     * @param callable(): AbstractModule $modules
+     * @param array<class-string>        $savedSingletons
+     */
+    private static function getInjector(callable $modules, string $scriptDir, array $savedSingletons, ?AbstractModule $module = null): InjectorInterface
     {
+        if ($module !== null) {
+            $modules = new OverrideLazyModule($modules, $module);
+        }
+
         $injector = InjectorFactory::getInstance($modules, $scriptDir);
         foreach ($savedSingletons as $singleton) {
             $injector->getInstance($singleton);

--- a/src/ContextInjector.php
+++ b/src/ContextInjector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ray\Compiler;
 
+use Ray\Di\AbstractModule;
 use Ray\Di\InjectorInterface;
 
 use function get_class;
@@ -24,6 +25,18 @@ final class ContextInjector
             $injectorContext->tmpDir,
             $injectorContext,
             $injectorContext->getCache(),
+            $injectorContext->getSavedSingleton()
+        );
+    }
+
+    public static function getOverrideInstance(
+        AbstractInjectorContext $injectorContext,
+        AbstractModule $overrideModule
+    ): InjectorInterface {
+        return CachedInjectorFactory::getOverrideInstance(
+            $injectorContext->tmpDir,
+            $injectorContext,
+            $overrideModule,
             $injectorContext->getSavedSingleton()
         );
     }

--- a/src/OverrideLazyModule.php
+++ b/src/OverrideLazyModule.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+use Ray\Di\AbstractModule;
+
+class OverrideLazyModule implements LazyModuleInterface
+{
+    /** @var callable(): AbstractModule */
+    private $modules;
+
+    /** @var AbstractModule */
+    private $overrideModule;
+
+    /** @param callable(): AbstractModule $modules */
+    public function __construct(callable $modules, AbstractModule $overrideModule)
+    {
+        $this->modules = $modules;
+        $this->overrideModule = $overrideModule;
+    }
+
+    public function __invoke(): AbstractModule
+    {
+        $module = ($this->modules)();
+        $module->override($this->overrideModule);
+
+        return $module;
+    }
+}

--- a/tests/ContextInjectorTest.php
+++ b/tests/ContextInjectorTest.php
@@ -9,6 +9,7 @@ use Ray\Compiler\Deep\FakeDeep;
 use Ray\Compiler\Deep\FakeDemand;
 use Ray\Compiler\Deep\FakeInjectorContext;
 use Ray\Compiler\Deep\FakeScriptInjectorContext;
+use Ray\Di\AbstractModule;
 use Ray\Di\Injector;
 use Ray\Di\InjectorInterface;
 
@@ -63,5 +64,20 @@ class ContextInjectorTest extends TestCase
         $this->assertFalse($deep2->dep->changed);
         $demand = $injector->getInstance(FakeDemand::class);
         $this->assertInstanceOf(FakeDemand::class, $demand);
+    }
+
+    public function testGetOverrideInstance(): void
+    {
+        $overrideModule = new class extends AbstractModule {
+            protected function configure()
+            {
+                $this->bind(FakeRobotInterface::class)->to(FakeDevRobot::class);
+            }
+        };
+
+        $injector = ContextInjector::getOverrideInstance(new FakeTestContext(__DIR__ . '/tmp/base'), $overrideModule);
+
+        $this->assertInstanceOf(Injector::class, $injector);
+        $this->assertInstanceOf(FakeDevRobot::class, $injector->getInstance(FakeRobotInterface::class));
     }
 }


### PR DESCRIPTION
Fix: #101 

`CachedInjectorFactory::getOverrideInstance` を実装しました。

主にテスト実行時のコンテキストにおいて、コンテキストは変えずに束縛を変更したい際に利用することを想定しています。