### PR TITLE
Log bindings in script directory

### DIFF
--- a/src/CompileInjector.php
+++ b/src/CompileInjector.php
@@ -198,6 +198,7 @@ final class CompileInjector implements ScriptInjectorInterface
     public function compile(): void
     {
         $module = (new InstallBuiltinModule())(($this->lazyModule)());
+        (new FilePutContents())(sprintf('%s/_bindings.log', $this->scriptDir), (string) $module);
         (new Bind($module->getContainer(), ''))->annotatedWith(ScriptDir::class)->toInstance($this->scriptDir);
         (new DiCompiler($module, $this->scriptDir))->compileContainer();
     }

--- a/src/CompileInjector.php
+++ b/src/CompileInjector.php
@@ -10,6 +10,7 @@ use Ray\Di\Bind;
 use Ray\Di\Name;
 use ReflectionParameter;
 
+use function error_log;
 use function file_exists;
 use function in_array;
 use function rtrim;
@@ -197,6 +198,7 @@ final class CompileInjector implements ScriptInjectorInterface
 
     public function compile(): void
     {
+        error_log(sprintf('compile: %s', __CLASS__));
         $module = (new InstallBuiltinModule())(($this->lazyModule)());
         (new Bind($module->getContainer(), ''))->annotatedWith(ScriptDir::class)->toInstance($this->scriptDir);
         (new DiCompiler($module, $this->scriptDir))->compileContainer();

--- a/src/DiCompiler.php
+++ b/src/DiCompiler.php
@@ -17,6 +17,7 @@ use function assert;
 use function fclose;
 use function fopen;
 use function fwrite;
+use function is_resource;
 use function is_string;
 use function ksort;
 use function serialize;
@@ -90,6 +91,7 @@ final class DiCompiler implements InjectorInterface
         $container = $this->container->getContainer();
         assert(is_string($scriptDir));
         $fp = fopen(sprintf('%s/_compile.log', $this->scriptDir), 'a');
+        assert(is_resource($fp));
         ksort($container);
         foreach ($container as $dependencyIndex => $dependency) {
             fwrite($fp, $dependencyIndex . PHP_EOL);

--- a/src/ScriptInjector.php
+++ b/src/ScriptInjector.php
@@ -310,6 +310,7 @@ final class ScriptInjector implements ScriptInjectorInterface
         $compiler = new DiCompiler($this->module, $this->scriptDir);
         $compiler->savePointcuts($this->module->getContainer());
         $this->saveModule();
+        error_log(sprintf('compile: %s', __CLASS__));
         $compiler->compile();
     }
 


### PR DESCRIPTION
Save the following binding log in the `sciript/_bindings.log` file.
You can see what is bound for an interface and to which methods AOP is applied.

以下のような束縛ログを `sciript/_bindings.log`ファイルに保存します。
インターフェイスに対して何が束縛され、どのメソッドにAOPが適用されるかを知ることができます。

```
-Ray\Compiler\Annotation\Compile => (boolean) 1
-logo => (string) momo
Doctrine\Common\Annotations\Reader- => (provider) (dependency) Ray\Compiler\ReaderProvider
Koriym\ParamReader\ParamReaderInterface- => (dependency) Koriym\ParamReader\ParamReader
Ray\Aop\MethodInvocation- => (provider) (dependency) Ray\Di\MethodInvocationProvider
Ray\Compiler\FakeCar- => (dependency) Ray\Compiler\FakeCar (aop) +setTires(Ray\Compiler\FakeInterceptor) +setHardtop(Ray\Compiler\FakeInterceptor) +setMirrors(Ray\Compiler\FakeInterceptor) +setSpareMirror(Ray\Compiler\FakeInterceptor) +setHandle(Ray\Compiler\FakeInterceptor) +postConstruct(Ray\Compiler\FakeInterceptor)
Ray\Compiler\FakeCarInterface- => (dependency) Ray\Compiler\FakeCar (aop) +setTires(Ray\Compiler\FakeInterceptor) +setHardtop(Ray\Compiler\FakeInterceptor) +setMirrors(Ray\Compiler\FakeInterceptor) +setSpareMirror(Ray\Compiler\FakeInterceptor) +setHandle(Ray\Compiler\FakeInterceptor) +postConstruct(Ray\Compiler\FakeInterceptor)
Ray\Compiler\FakeEngineInterface- => (dependency) Ray\Compiler\FakeEngine
Ray\Compiler\FakeHandleInterface- => (provider) (dependency) Ray\Compiler\FakeHandleProvider
Ray\Compiler\FakeHardtopInterface- => (dependency) Ray\Compiler\FakeHardtop
Ray\Compiler\FakeInterceptor- => (dependency) Ray\Compiler\FakeInterceptor
Ray\Compiler\FakeLoggerConsumer- => (dependency) Ray\Compiler\FakeLoggerConsumer (aop) +setLogger(Ray\Compiler\FakeInterceptor)
Ray\Compiler\FakeLoggerInterface-Ray\Compiler\FakeLoggerInject => (provider) (dependency) Ray\Compiler\FakeLoggerPointProvider
Ray\Compiler\FakeMirrorInterface-left => (dependency) Ray\Compiler\FakeMirrorLeft
Ray\Compiler\FakeMirrorInterface-right => (dependency) Ray\Compiler\FakeMirrorRight
Ray\Compiler\FakeRobot- => (dependency) Ray\Compiler\FakeRobot
Ray\Compiler\FakeRobotInterface- => (dependency) Ray\Compiler\FakeRobot
Ray\Compiler\FakeTyreInterface- => (dependency) Ray\Compiler\FakeTyre
Ray\Di\AssistedInjectInterceptor- => (dependency) Ray\Di\AssistedInjectInterceptor
Ray\Di\AssistedInterceptor- => (dependency) Ray\Di\AssistedInterceptor
Ray\Di\MethodInvocationProvider- => (dependency) Ray\Di\MethodInvocationProvider
Ray\Di\MultiBinding\Map- => (provider) (dependency) Ray\Di\MultiBinding\MapProvider
Ray\Di\MultiBinding\MultiBindings- => (object) Ray\Di\MultiBinding\MultiBindings
Ray\Di\ProviderInterface- => (provider) (dependency) Ray\Di\ProviderSetProvider
```

加えて、`sciript/_compile.log`ファイルにどの依存をコンパイルしたかを記録します。

```
-Ray\Di\Annotation\ScriptDir
Doctrine\Common\Annotations\Reader-
Koriym\ParamReader\ParamReaderInterface-
Ray\Aop\MethodInvocation-
Ray\Compiler\FakeRobotInterface-
Ray\Di\AssistedInjectInterceptor-
Ray\Di\AssistedInterceptor-
Ray\Di\InjectorInterface-
Ray\Di\MethodInvocationProvider-
Ray\Di\ProviderInterface-
```
