### PR TITLE
Update InjectionPoint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Ray\\Compiler\\": ["src"]
+            "Ray\\Compiler\\": ["src", "src-deprecated"]
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "koriym/null-object": "^1.0",
         "koriym/printo": "^1.0",
         "nikic/php-parser": "^4.5",
-        "ray/aop": "^2.10"
+        "ray/aop": "^2.14"
     },
     "require-dev": {
         "ext-pdo": "*",

--- a/src-deprecated/ReaderProvider.php
+++ b/src-deprecated/ReaderProvider.php
@@ -8,6 +8,10 @@ use Doctrine\Common\Annotations\Reader;
 use Ray\Di\ProviderInterface;
 use Ray\ServiceLocator\ServiceLocator;
 
+/**
+ * @deprecated
+ * @codeCoverageIgnore
+ */
 final class ReaderProvider implements ProviderInterface
 {
     public function get(): Reader

--- a/src/CachedInjectorFactory.php
+++ b/src/CachedInjectorFactory.php
@@ -18,10 +18,6 @@ final class CachedInjectorFactory
     /** @var array<string, string> */
     private static $injectors = [];
 
-    private function __construct()
-    {
-    }
-
     /**
      * @param callable(): AbstractModule $modules
      * @param array<class-string>        $savedSingletons

--- a/src/CompileInjector.php
+++ b/src/CompileInjector.php
@@ -167,7 +167,7 @@ final class CompileInjector implements ScriptInjectorInterface
         touch($checkFile);
         $this->compile();
         if (! file_exists($file)) {
-            throw new Unbound($dependencyIndex);
+            throw new Unbound($dependencyIndex); // @codeCoverageIgnore
         }
 
         return $file;

--- a/src/ContextInjector.php
+++ b/src/ContextInjector.php
@@ -14,10 +14,6 @@ use function get_class;
  */
 final class ContextInjector
 {
-    private function __construct()
-    {
-    }
-
     public static function getInstance(AbstractInjectorContext $injectorContext): InjectorInterface
     {
         return CachedInjectorFactory::getInstance(

--- a/src/FilePutContents.php
+++ b/src/FilePutContents.php
@@ -30,5 +30,6 @@ final class FilePutContents
         @unlink((string) $tmpFile);
 
         throw new FileNotWritable($filename);
+        // @codeCoverageIgnoreEnd
     }
 }

--- a/src/InjectionPoint.php
+++ b/src/InjectionPoint.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Ray\Compiler;
 
+use Ray\Aop\ReflectionClass;
 use Ray\Aop\ReflectionMethod;
 use Ray\Di\InjectionPointInterface;
-use ReflectionClass;
 use ReflectionParameter;
 use RuntimeException;
 
@@ -44,15 +44,15 @@ final class InjectionPoint implements InjectionPointInterface
     /**
      * {@inheritdoc}
      */
-    public function getMethod(): \ReflectionMethod
+    public function getMethod(): ReflectionMethod
     {
         $this->parameter = $this->getParameter();
         $class = $this->parameter->getDeclaringClass();
-        assert($class instanceof ReflectionClass);
         $method = $this->parameter->getDeclaringFunction()->getShortName();
-        assert(class_exists($class->name));
+        assert($class instanceof \ReflectionClass);
+        assert(class_exists($class->getName()));
 
-        return new ReflectionMethod($class->name, $method);
+        return new ReflectionMethod($class->getName(), $method);
     }
 
     /**
@@ -61,9 +61,9 @@ final class InjectionPoint implements InjectionPointInterface
     public function getClass(): ReflectionClass
     {
         $class = $this->parameter->getDeclaringClass();
-        assert($class instanceof ReflectionClass);
+        assert($class instanceof \ReflectionClass);
 
-        return $class;
+        return new ReflectionClass($class->getName());
     }
 
     /**
@@ -86,7 +86,7 @@ final class InjectionPoint implements InjectionPointInterface
     public function getQualifier()
     {
         $class = $this->parameter->getDeclaringClass();
-        assert($class instanceof ReflectionClass);
+        assert($class instanceof \ReflectionClass);
 
         $qualifierFile = sprintf(
             ScriptInjector::QUALIFIER,

--- a/src/InjectorFactory.php
+++ b/src/InjectorFactory.php
@@ -18,10 +18,6 @@ use function mkdir;
  */
 final class InjectorFactory
 {
-    private function __construct()
-    {
-    }
-
     /**
      * @param callable(): AbstractModule $modules
      */

--- a/src/IpQualifier.php
+++ b/src/IpQualifier.php
@@ -24,6 +24,6 @@ final class IpQualifier
 
     public function __toString(): string
     {
-        return serialize($this->qualifier); // @codeCoverageIgnoreStart
+        return serialize($this->qualifier); // @codeCoverageIgnore
     }
 }

--- a/src/OnDemandCompiler.php
+++ b/src/OnDemandCompiler.php
@@ -82,7 +82,7 @@ final class OnDemandCompiler
     {
         $pointcutsPath = $this->scriptDir . ScriptInjector::AOP;
         if (! file_exists($pointcutsPath)) {
-            return false; // @codeCoverageIgnoreStart
+            return false; // @codeCoverageIgnore
         }
 
         $serialized = file_get_contents($pointcutsPath);

--- a/src/PramReaderModule.php
+++ b/src/PramReaderModule.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Ray\Compiler;
 
-use Doctrine\Common\Annotations\Reader;
 use Koriym\ParamReader\ParamReader;
 use Koriym\ParamReader\ParamReaderInterface;
 use Ray\Di\AbstractModule;
-use Ray\Di\Scope;
 
 class PramReaderModule extends AbstractModule
 {
@@ -18,6 +16,5 @@ class PramReaderModule extends AbstractModule
     protected function configure(): void
     {
         $this->bind(ParamReaderInterface::class)->to(ParamReader::class);
-        $this->bind(Reader::class)->toProvider(ReaderProvider::class)->in(Scope::SINGLETON);
     }
 }

--- a/tests/CompileInjectorTest.php
+++ b/tests/CompileInjectorTest.php
@@ -36,7 +36,6 @@ class CompileInjectorTest extends TestCase
         $this->assertFileExists(__DIR__ . '/tmp/-Ray_Di_Annotation_ScriptDir.php');
         $this->assertFileExists(__DIR__ . '/tmp/Ray_Aop_MethodInvocation-.php');
         $this->assertFileExists(__DIR__ . '/tmp/Koriym_ParamReader_ParamReaderInterface-.php');
-        $this->assertFileExists(__DIR__ . '/tmp/Doctrine_Common_Annotations_Reader-.php');
         $this->assertFileExists(__DIR__ . '/tmp/Ray_Di_AssistedInterceptor-.php');
         $this->assertFileExists(__DIR__ . '/tmp/Ray_Di_InjectorInterface-.php');
         $this->assertFileExists(__DIR__ . '/tmp/Ray_Di_MethodInvocationProvider-.php');


### PR DESCRIPTION
Related: https://github.com/ray-di/Ray.Di/pull/284

InjectionPointInterface signature changed in Ray.Di.

CacheReader が parameter のアノテーションを読み込む処理を持たないので、ReaderProvider を利用せず、ParamReader 側に処理を任せてしまっています。

CacheReader を利用する場合は、CacheReader に パラメーターのアノテーションを読む処理を実装する必要があります。