### PR TITLE
Add wakeup call in CompileInjector

### DIFF
--- a/src/CompileInjector.php
+++ b/src/CompileInjector.php
@@ -134,7 +134,9 @@ final class CompileInjector implements ScriptInjectorInterface
         }
 
         if ($this->functions === null) {
+            // @codeCoverageIgnoreStart
             $this->__wakeup();
+            // @codeCoverageIgnoreEnd
         }
 
         [$prototype, $singleton, $injectionPoint, $injector] = $this->functions;

--- a/src/CompileInjector.php
+++ b/src/CompileInjector.php
@@ -133,6 +133,7 @@ final class CompileInjector implements ScriptInjectorInterface
             return $this->singletons[$dependencyIndex];
         }
 
+        /** @psalm-suppress DocblockTypeContradiction */
         if ($this->functions === null) {
             // @codeCoverageIgnoreStart
             $this->__wakeup();

--- a/src/CompileInjector.php
+++ b/src/CompileInjector.php
@@ -133,6 +133,10 @@ final class CompileInjector implements ScriptInjectorInterface
             return $this->singletons[$dependencyIndex];
         }
 
+        if ($this->functions === null) {
+            $this->__wakeup();
+        }
+
         [$prototype, $singleton, $injectionPoint, $injector] = $this->functions;
         /** @psalm-suppress UnresolvableInclude */
         $instance = require $this->getInstanceFile($dependencyIndex);


### PR DESCRIPTION
A wakeup call has been added to the CompileInjector to ensure that the injector functions are initialized before proceeding. This provides a fail-safe measure that guarantees the availability of these functions whenever needed.

See https://github.com/koriym/BEAR.SpikeProject/issues/1

外部から__wakeupをコールする方法も検討しましたが、将来的なマジックメソッド廃止のオプションをキープするために対処療法的な解決策にしました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced serialization and deserialization capabilities in the `FakeHavingCompileInjector` for enhanced data handling.
- **Bug Fixes**
  - Added a safety check in `CompileInjector` to prevent errors when accessing uninitialized functions, ensuring smoother operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->