### PR TITLE
Add PHP 8.5 support to CI

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,5 +9,5 @@ jobs:
   ci:
     uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]'
-      current_stable: 8.4
+      old_stable: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4"]'
+      current_stable: 8.5

--- a/composer.json
+++ b/composer.json
@@ -12,14 +12,15 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "doctrine/cache": "^1.10 || ^2.1",
         "doctrine/annotations": "^1.8 || ^2.0",
+        "doctrine/cache": "^1.10 || ^2.1",
         "koriym/attributes": "^1.0",
         "koriym/null-object": "^1.0",
         "koriym/param-reader": "^1.0",
         "koriym/printo": "^1.0",
         "ray/aop": "^2.14",
-        "ray/di": "^2.18"
+        "ray/di": "^2.18",
+        "symfony/polyfill-php83": "^1.33"
     },
     "require-dev": {
         "ext-pdo": "*",

--- a/psalm.xml
+++ b/psalm.xml
@@ -10,6 +10,7 @@
         <directory name="src" />
         <ignoreFiles>
             <directory name="vendor" />
+            <directory name="src-deprecated" />
         </ignoreFiles>
     </projectFiles>
     <issueHandlers>

--- a/src-deprecated/Code.php
+++ b/src-deprecated/Code.php
@@ -8,7 +8,7 @@ use PhpParser\Node;
 use PhpParser\PrettyPrinter\Standard;
 
 /** @deprecated Use CompileInjector instead */
-final class Code
+class Code
 {
     /** @var bool */
     public $isSingleton;

--- a/src-deprecated/Code4Dependency.php
+++ b/src-deprecated/Code4Dependency.php
@@ -21,6 +21,7 @@ use function var_export;
 
 use const PHP_EOL;
 
+/** @deprecated */
 final class Code4Dependency extends Code
 {
     /** @var Dependency */

--- a/src-deprecated/DependencyCode.php
+++ b/src-deprecated/DependencyCode.php
@@ -51,6 +51,9 @@ final class DependencyCode implements SetContextInterface
     /** @var AopCode */
     private $aopCode;
 
+    /** @var Container */
+    private $container;
+
     public function __construct(Container $container, ?ScriptInjector $injector = null)
     {
         $this->factory = new BuilderFactory();
@@ -58,6 +61,7 @@ final class DependencyCode implements SetContextInterface
         $this->factoryCompiler = new FactoryCode($container, new Normalizer(), $this, $injector);
         $this->privateProperty = new PrivateProperty();
         $this->aopCode = new AopCode($this->privateProperty);
+        $this->container = $container;
     }
 
     /**
@@ -66,7 +70,7 @@ final class DependencyCode implements SetContextInterface
     public function getCode(DependencyInterface $dependency): Code
     {
         if ($dependency instanceof Dependency) {
-            return $this->getDependencyCode($dependency);
+            return $this->getDependencyCode($dependency,);
         }
 
         if ($dependency instanceof Instance) {
@@ -115,8 +119,10 @@ final class DependencyCode implements SetContextInterface
      */
     private function getDependencyCode(Dependency $dependency): Code
     {
-        $prop = $this->privateProperty;
-        $node = $this->getFactoryNode($dependency);
+        return new Code4Dependency($this->container, $dependency, $this->qualifier);
+
+//        $prop = $this->privateProperty;
+//        $node = $this->getFactoryNode($dependency);
         ($this->aopCode)($dependency, $node);
         /** @var bool $isSingleton */
         $isSingleton = $prop($dependency, 'isSingleton');

--- a/src-deprecated/DiCompiler.php
+++ b/src-deprecated/DiCompiler.php
@@ -101,7 +101,7 @@ final class DiCompiler implements InjectorInterface
         foreach ($container as $dependencyIndex => $dependency) {
             fwrite($fp, sprintf("Compiled: %s\n", $dependencyIndex));
             try {
-                $code = $this->dependencyCompiler->getCode($dependency);
+                $code = $this->dependencyCompiler->getCode($dependency, $container);
             } catch (Unbound $e) {
                 fwrite($fp, sprintf("\nError: %s\nUnbound: %s\n", $dependencyIndex, $e->getMessage()));
 

--- a/src-deprecated/NullDependendy.php
+++ b/src-deprecated/NullDependendy.php
@@ -6,6 +6,7 @@ use Ray\Di\Bind;
 use Ray\Di\Container;
 use Ray\Di\DependencyInterface;
 
+/** @deprecated */
 final class NullDependendy implements DependencyInterface
 {
     public function __toString()

--- a/src/AbstractInjectorContext.php
+++ b/src/AbstractInjectorContext.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ray\Compiler;
 
 use Doctrine\Common\Cache\CacheProvider;
+use Override;
 use Ray\Di\AbstractModule;
 use Ray\Di\Annotation\ScriptDir;
 
@@ -23,7 +24,7 @@ abstract class AbstractInjectorContext implements LazyModuleInterface
         $this->tmpDir = $tmpDir;
     }
 
-    #[\Override]
+    #[Override]
     abstract public function __invoke(): AbstractModule;
 
     abstract public function getCache(): CacheProvider;

--- a/src/AbstractInjectorContext.php
+++ b/src/AbstractInjectorContext.php
@@ -23,6 +23,7 @@ abstract class AbstractInjectorContext implements LazyModuleInterface
         $this->tmpDir = $tmpDir;
     }
 
+    #[\Override]
     abstract public function __invoke(): AbstractModule;
 
     abstract public function getCache(): CacheProvider;

--- a/src/AbstractInjectorContext.php
+++ b/src/AbstractInjectorContext.php
@@ -9,7 +9,10 @@ use Override;
 use Ray\Di\AbstractModule;
 use Ray\Di\Annotation\ScriptDir;
 
-/** @psalm-import-type ScriptDir from Types */
+/**
+ * @psalm-import-type ScriptDir from Types
+ * @psalm-import-type SavedSingletons from Types
+ */
 abstract class AbstractInjectorContext implements LazyModuleInterface
 {
     /**
@@ -32,7 +35,7 @@ abstract class AbstractInjectorContext implements LazyModuleInterface
     /**
      * Return array of cacheable singleton class names
      *
-     * @return array<class-string>
+     * @return SavedSingletons
      */
     public function getSavedSingleton(): array
     {

--- a/src/CachedInjectorFactory.php
+++ b/src/CachedInjectorFactory.php
@@ -6,7 +6,6 @@ namespace Ray\Compiler;
 
 use Doctrine\Common\Cache\CacheProvider;
 use Ray\Di\AbstractModule;
-use Ray\Di\Annotation\ScriptDir;
 use Ray\Di\InjectorInterface;
 use Ray\Di\NullCache;
 
@@ -15,15 +14,16 @@ use function serialize;
 use function unserialize;
 
 /** @psalm-import-type ScriptDir from Types */
+/** @psalm-import-type SavedSingletons from Types */
 final class CachedInjectorFactory
 {
     /** @var array<string, string> */
     private static $injectors = [];
 
     /**
+     * @param non-empty-string           $scriptDir
      * @param callable(): AbstractModule $modules
-     * @param array<class-string>        $savedSingletons
-     * @param ScriptDir                  $scriptDir
+     * @param SavedSingletons            $savedSingletons
      */
     public static function getInstance(string $injectorId, string $scriptDir, callable $modules, ?CacheProvider $cache = null, array $savedSingletons = []): InjectorInterface
     {
@@ -55,9 +55,9 @@ final class CachedInjectorFactory
     }
 
     /**
+     * @param non-empty-string           $scriptDir
      * @param callable(): AbstractModule $modules
-     * @param array<class-string>        $savedSingletons
-     *                                                   @param ScriptDir                  $scriptDir
+     * @param SavedSingletons            $savedSingletons
      */
     public static function getOverrideInstance(
         string $scriptDir,
@@ -70,8 +70,8 @@ final class CachedInjectorFactory
 
     /**
      * @param callable(): AbstractModule $modules
-     * @param array<class-string>        $savedSingletons
-     * @param ScriptDir                  $scriptDir
+     * @param non-empty-string           $scriptDir
+     * @param SavedSingletons            $savedSingletons
      */
     private static function getInjector(callable $modules, string $scriptDir, array $savedSingletons, ?AbstractModule $module = null): InjectorInterface
     {

--- a/src/Code4Dependency.php
+++ b/src/Code4Dependency.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+use Ray\Compiler\Exception\Unbound;
+use Ray\Di\Argument;
+use Ray\Di\Bind;
+use Ray\Di\Container;
+use Ray\Di\Dependency;
+use Ray\Di\DependencyInterface;
+use Ray\Di\NewInstance;
+
+use Ray\Di\SetterMethod;
+use Ray\Di\SetterMethods;
+use function implode;
+use function is_array;
+use function sprintf;
+
+use function var_export;
+use const PHP_EOL;
+
+class Code4Dependency extends Code
+{
+    /** @var Dependency */
+    private $dependency;
+    /** @var PrivateProperty  */
+    private $prop;
+    /**
+     * @var DependencyInterface[]
+     */
+    private $container;
+
+    /**
+     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
+     */
+    public function __construct(Container $container, Dependency $dependency, ?IpQualifier $qualifier = null)
+    {
+        $this->dependency = $dependency;
+        $this->qualifiers = $qualifier;
+        $this->prop = new PrivateProperty();
+        $this->container = $container->getContainer();
+    }
+
+    public function __toString(): string
+    {
+        $lines = $this->getNewInstanceCode();
+        $this->addBindingCode($lines);
+        $this->addSetterCode($lines);
+        $lines[] = 'return $instance;';
+
+        return implode(PHP_EOL, $lines);
+    }
+
+    private function addSetterCode(array &$lines)
+    {
+        $newInstance = ($this->prop)($this->dependency, 'newInstance');
+        // class name
+        /** @var class-string $class */
+        $class = ($this->prop)($newInstance, 'class');
+        /** @var SetterMethods $setterMethodsObject */
+        $setterMethodsObject = ($this->prop)($newInstance, 'setterMethods');
+        /** @var array<SetterMethod> $setterMethods */
+        $setterMethods = (array) ($this->prop)($setterMethodsObject, 'setterMethods');
+        foreach ($setterMethods as $setterMethod) {
+            $methodName = ($this->prop)($setterMethod, 'method');
+            $arguments = ($this->prop)($setterMethod, 'arguments');
+            $arguments = ($this->prop)($arguments, 'arguments');
+            $args = [];
+            foreach ($arguments as $argument) {
+                $index = ($this->prop)($argument, 'index');
+                $args[] = $this->getArgumentCode($argument, $index);
+            }
+            if ($args === []) {
+                return;
+            }
+
+            $argString = implode(', ', $args);
+            $lines[] = sprintf('$instance->%s(%s);', $methodName, $argString);
+        }
+    }
+
+    private function addBindingCode(array &$lines): void
+    {
+        /** @var ?NewInstance */
+        $newInstance = ($this->prop)($this->dependency, 'newInstance');
+        /** @var ?Bind */
+        $bind = ($this->prop)($newInstance, 'bind');
+        /** @var ?Bind */
+        $aspectBind = ($this->prop)($bind, 'bind');
+        /** @var string[][]|null $bindings */
+        $bindings = ($this->prop)($aspectBind, 'bindings', null);
+
+        if ($bindings === null) {
+            return;
+        }
+
+        $line = '$instance->bindings = ' . $this->getBindingsCode($bindings) . ';';
+        $lines[] = $line;
+    }
+
+    private function getBindingsCode(array $bindings): string
+    {
+        $methodBinding = [];
+        foreach ($bindings as $method => $interceptors) {
+            $methodBinding[] = sprintf("'%s' => [%s]", $method, $this->getInterceptorCode($interceptors));
+        }
+
+        return '[' . implode(', ', $methodBinding) . ']';
+    }
+
+    /** @ */
+    private function getInterceptorCode(array $interceptors): string
+    {
+        $interceptorCode = [];
+        foreach ($interceptors as $interceptor) {
+            $interceptorCode[] = sprintf('$singleton(\'%s-\')', $interceptor);
+        }
+
+        return implode(', ', $interceptorCode);
+    }
+
+    /**
+     * @param PrivateProperty $prop
+     *
+     * @return array
+     */
+    public function getNewInstanceCode(): array
+    {
+
+        $newInstance = ($this->prop)($this->dependency, 'newInstance');
+        $className = ($this->prop)($newInstance, 'class');
+
+        $arguments = ($this->prop)(($this->prop)($newInstance, 'arguments'), 'arguments');
+        $args = [];
+        if (is_array($arguments)) {
+            foreach ($arguments as $argument) {
+                $index = ($this->prop)($argument, 'index');
+                $args[] = $this->getArgumentCode($argument, $index);
+            }
+        }
+
+        $argString = implode(', ', $args);
+        $lines = [sprintf("<?php\n\$instance = new %s(%s);", $className, $argString)];
+        return $lines;
+    }
+
+    /**
+     * @param $index
+     *
+     * @return string
+     */
+    public function getArgumentCode(Argument  $argument, string $index): string
+    {
+        if (isset($this->container[$index])) {
+            return sprintf('$prototype(\'%s\')', $index);
+        }
+       if ($argument->isDefaultAvailable()) {
+           return var_export($argument->getDefaultValue(), true);
+       }
+       throw new Unbound($index);
+    }
+}

--- a/src/Code4Dependency.php
+++ b/src/Code4Dependency.php
@@ -32,9 +32,7 @@ class Code4Dependency extends Code
      */
     private $container;
 
-    /**
-     * @SuppressWarnings(PHPMD.BooleanArgumentFlag)
-     */
+    /** @SuppressWarnings("PHPMD.BooleanArgumentFlag") */
     public function __construct(Container $container, Dependency $dependency, ?IpQualifier $qualifier = null)
     {
         $this->dependency = $dependency;
@@ -53,7 +51,10 @@ class Code4Dependency extends Code
         return implode(PHP_EOL, $lines);
     }
 
-    private function addSetterCode(array &$lines)
+    /**
+     * @param array<string> $lines
+     */
+    private function addSetterCode(array &$lines): void
     {
         $newInstance = ($this->prop)($this->dependency, 'newInstance');
         // class name
@@ -81,6 +82,9 @@ class Code4Dependency extends Code
         }
     }
 
+    /**
+     * @param array<string> $lines
+     */
     private function addBindingCode(array &$lines): void
     {
         /** @var ?NewInstance */
@@ -100,6 +104,9 @@ class Code4Dependency extends Code
         $lines[] = $line;
     }
 
+    /**
+     * @param array<string, array<string>> $bindings
+     */
     private function getBindingsCode(array $bindings): string
     {
         $methodBinding = [];
@@ -110,7 +117,9 @@ class Code4Dependency extends Code
         return '[' . implode(', ', $methodBinding) . ']';
     }
 
-    /** @ */
+    /**
+     * @param array<string> $interceptors
+     */
     private function getInterceptorCode(array $interceptors): string
     {
         $interceptorCode = [];
@@ -122,9 +131,7 @@ class Code4Dependency extends Code
     }
 
     /**
-     * @param PrivateProperty $prop
-     *
-     * @return array
+     * @return array<string>
      */
     public function getNewInstanceCode(): array
     {
@@ -146,11 +153,6 @@ class Code4Dependency extends Code
         return $lines;
     }
 
-    /**
-     * @param $index
-     *
-     * @return string
-     */
     public function getArgumentCode(Argument  $argument, string $index): string
     {
         if (isset($this->container[$index])) {

--- a/src/Code4Dependency.php
+++ b/src/Code4Dependency.php
@@ -11,25 +11,25 @@ use Ray\Di\Container;
 use Ray\Di\Dependency;
 use Ray\Di\DependencyInterface;
 use Ray\Di\NewInstance;
-
 use Ray\Di\SetterMethod;
 use Ray\Di\SetterMethods;
+
 use function implode;
 use function is_array;
 use function sprintf;
-
 use function var_export;
+
 use const PHP_EOL;
 
 class Code4Dependency extends Code
 {
     /** @var Dependency */
     private $dependency;
+
     /** @var PrivateProperty  */
     private $prop;
-    /**
-     * @var DependencyInterface[]
-     */
+
+    /** @var DependencyInterface[] */
     private $container;
 
     /** @SuppressWarnings("PHPMD.BooleanArgumentFlag") */
@@ -51,9 +51,7 @@ class Code4Dependency extends Code
         return implode(PHP_EOL, $lines);
     }
 
-    /**
-     * @param array<string> $lines
-     */
+    /** @param array<string> $lines */
     private function addSetterCode(array &$lines): void
     {
         $newInstance = ($this->prop)($this->dependency, 'newInstance');
@@ -73,6 +71,7 @@ class Code4Dependency extends Code
                 $index = ($this->prop)($argument, 'index');
                 $args[] = $this->getArgumentCode($argument, $index);
             }
+
             if ($args === []) {
                 return;
             }
@@ -82,9 +81,7 @@ class Code4Dependency extends Code
         }
     }
 
-    /**
-     * @param array<string> $lines
-     */
+    /** @param array<string> $lines */
     private function addBindingCode(array &$lines): void
     {
         /** @var ?NewInstance */
@@ -104,9 +101,7 @@ class Code4Dependency extends Code
         $lines[] = $line;
     }
 
-    /**
-     * @param array<string, array<string>> $bindings
-     */
+    /** @param array<string, array<string>> $bindings */
     private function getBindingsCode(array $bindings): string
     {
         $methodBinding = [];
@@ -117,9 +112,7 @@ class Code4Dependency extends Code
         return '[' . implode(', ', $methodBinding) . ']';
     }
 
-    /**
-     * @param array<string> $interceptors
-     */
+    /** @param array<string> $interceptors */
     private function getInterceptorCode(array $interceptors): string
     {
         $interceptorCode = [];
@@ -130,12 +123,9 @@ class Code4Dependency extends Code
         return implode(', ', $interceptorCode);
     }
 
-    /**
-     * @return array<string>
-     */
+    /** @return array<string> */
     public function getNewInstanceCode(): array
     {
-
         $newInstance = ($this->prop)($this->dependency, 'newInstance');
         $className = ($this->prop)($newInstance, 'class');
 
@@ -149,18 +139,20 @@ class Code4Dependency extends Code
         }
 
         $argString = implode(', ', $args);
-        $lines = [sprintf("<?php\n\$instance = new %s(%s);", $className, $argString)];
-        return $lines;
+
+        return [sprintf("<?php\n\$instance = new %s(%s);", $className, $argString)];
     }
 
-    public function getArgumentCode(Argument  $argument, string $index): string
+    public function getArgumentCode(Argument $argument, string $index): string
     {
         if (isset($this->container[$index])) {
             return sprintf('$prototype(\'%s\')', $index);
         }
-       if ($argument->isDefaultAvailable()) {
-           return var_export($argument->getDefaultValue(), true);
-       }
-       throw new Unbound($index);
+
+        if ($argument->isDefaultAvailable()) {
+            return var_export($argument->getDefaultValue(), true);
+        }
+
+        throw new Unbound($index);
     }
 }

--- a/src/Code4Dependency.php
+++ b/src/Code4Dependency.php
@@ -21,7 +21,7 @@ use function var_export;
 
 use const PHP_EOL;
 
-class Code4Dependency extends Code
+final class Code4Dependency extends Code
 {
     /** @var Dependency */
     private $dependency;
@@ -36,6 +36,7 @@ class Code4Dependency extends Code
     public function __construct(Container $container, Dependency $dependency, ?IpQualifier $qualifier = null)
     {
         $this->dependency = $dependency;
+        $this->isSingleton = $dependency->isSingleton();
         $this->qualifiers = $qualifier;
         $this->prop = new PrivateProperty();
         $this->container = $container->getContainer();

--- a/src/CompileVisitor.php
+++ b/src/CompileVisitor.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ray\Compiler;
 
+use Override;
 use Ray\Aop\Bind;
 use Ray\Di\Arguments;
 use Ray\Di\AspectBind;
@@ -36,7 +37,7 @@ final class CompileVisitor implements VisitorInterface
     }
 
     /** @inheritDoc */
-    #[\Override]
+    #[Override]
     public function visitDependency(
         NewInstance $newInstance,
         ?string $postConstruct,
@@ -48,7 +49,7 @@ final class CompileVisitor implements VisitorInterface
     }
 
     /** @inheritDoc */
-    #[\Override]
+    #[Override]
     public function visitProvider(
         Dependency $dependency,
         string $context,
@@ -64,7 +65,7 @@ final class CompileVisitor implements VisitorInterface
     }
 
     /** @inheritDoc */
-    #[\Override]
+    #[Override]
     public function visitInstance($value): string
     {
         if ($value === null || is_scalar($value) || is_array($value)) {
@@ -77,14 +78,14 @@ final class CompileVisitor implements VisitorInterface
     }
 
     /** @inheritDoc */
-    #[\Override]
+    #[Override]
     public function visitAspectBind(Bind $aopBind): void
     {
         $this->script->pushAspectBind($aopBind);
     }
 
     /** @inheritDoc */
-    #[\Override]
+    #[Override]
     public function visitNewInstance(
         string $class,
         SetterMethods $setterMethods,
@@ -104,7 +105,7 @@ final class CompileVisitor implements VisitorInterface
     }
 
     /** @inheritDoc */
-    #[\Override]
+    #[Override]
     public function visitSetterMethods(
         array $setterMethods
     ) {
@@ -114,7 +115,7 @@ final class CompileVisitor implements VisitorInterface
     }
 
     /** @inheritDoc */
-    #[\Override]
+    #[Override]
     public function visitSetterMethod(string $method, Arguments $arguments): void
     {
         $arguments->accept($this);
@@ -122,7 +123,7 @@ final class CompileVisitor implements VisitorInterface
     }
 
     /** @inheritDoc */
-    #[\Override]
+    #[Override]
     public function visitArguments(array $arguments): void
     {
         foreach ($arguments as $argument) {
@@ -131,7 +132,7 @@ final class CompileVisitor implements VisitorInterface
     }
 
     /** @inheritDoc */
-    #[\Override]
+    #[Override]
     public function visitArgument(
         string $index,
         bool $isDefaultAvailable,

--- a/src/CompileVisitor.php
+++ b/src/CompileVisitor.php
@@ -36,6 +36,7 @@ final class CompileVisitor implements VisitorInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function visitDependency(
         NewInstance $newInstance,
         ?string $postConstruct,
@@ -47,6 +48,7 @@ final class CompileVisitor implements VisitorInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function visitProvider(
         Dependency $dependency,
         string $context,
@@ -62,6 +64,7 @@ final class CompileVisitor implements VisitorInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function visitInstance($value): string
     {
         if ($value === null || is_scalar($value) || is_array($value)) {
@@ -74,12 +77,14 @@ final class CompileVisitor implements VisitorInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function visitAspectBind(Bind $aopBind): void
     {
         $this->script->pushAspectBind($aopBind);
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function visitNewInstance(
         string $class,
         SetterMethods $setterMethods,
@@ -99,6 +104,7 @@ final class CompileVisitor implements VisitorInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function visitSetterMethods(
         array $setterMethods
     ) {
@@ -108,6 +114,7 @@ final class CompileVisitor implements VisitorInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function visitSetterMethod(string $method, Arguments $arguments): void
     {
         $arguments->accept($this);
@@ -115,6 +122,7 @@ final class CompileVisitor implements VisitorInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function visitArguments(array $arguments): void
     {
         foreach ($arguments as $argument) {
@@ -123,6 +131,7 @@ final class CompileVisitor implements VisitorInterface
     }
 
     /** @inheritDoc */
+    #[\Override]
     public function visitArgument(
         string $index,
         bool $isDefaultAvailable,

--- a/src/CompiledInjector.php
+++ b/src/CompiledInjector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ray\Compiler;
 
+use Override;
 use Ray\Compiler\Exception\ScriptDirNotReadable;
 use Ray\Compiler\Exception\Unbound;
 use Ray\Di\Annotation\ScriptDir;
@@ -75,7 +76,7 @@ final class CompiledInjector implements ScriptInjectorInterface
      * @template T
      * @SuppressWarnings(PHPMD.UnusedLocalVariable) // @phpstan-ignore-line
      */
-    #[\Override]
+    #[Override]
     public function getInstance($interface, $name = Name::ANY)
     {
         $dependencyIndex = $interface . '-' . $name;

--- a/src/CompiledInjector.php
+++ b/src/CompiledInjector.php
@@ -28,6 +28,7 @@ use function str_replace;
  *
  * @psalm-import-type ScriptDir from Types
  * @psalm-import-type Singletons from Types
+ * @psalm-import-type ScriptDirs from Types
  */
 final class CompiledInjector implements ScriptInjectorInterface
 {
@@ -41,7 +42,10 @@ final class CompiledInjector implements ScriptInjectorInterface
      */
     private $singletons = [];
 
-    /** @var array<ScriptDir> */
+    /**
+     * @psalm-import-type ScriptDirs from Types
+     * @var ScriptDirs
+     */
     private static $scriptDirs = [];
 
     /**

--- a/src/CompiledInjector.php
+++ b/src/CompiledInjector.php
@@ -75,6 +75,7 @@ final class CompiledInjector implements ScriptInjectorInterface
      * @template T
      * @SuppressWarnings(PHPMD.UnusedLocalVariable) // @phpstan-ignore-line
      */
+    #[\Override]
     public function getInstance($interface, $name = Name::ANY)
     {
         $dependencyIndex = $interface . '-' . $name;

--- a/src/CompilerModule.php
+++ b/src/CompilerModule.php
@@ -28,6 +28,7 @@ class CompilerModule extends AbstractModule
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     protected function configure(): void
     {
         $this->bind()->annotatedWith(Compile::class)->toInstance(true);

--- a/src/CompilerModule.php
+++ b/src/CompilerModule.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ray\Compiler;
 
+use Override;
 use Ray\Compiler\Annotation\Compile;
 use Ray\Di\AbstractModule;
 use Ray\Di\Annotation\ScriptDir;
@@ -13,7 +14,7 @@ use Ray\Di\Scope;
 
 use function sprintf;
 
-class CompilerModule extends AbstractModule
+final class CompilerModule extends AbstractModule
 {
     /** @var string */
     private $scriptDir;
@@ -28,7 +29,7 @@ class CompilerModule extends AbstractModule
     /**
      * {@inheritDoc}
      */
-    #[\Override]
+    #[Override]
     protected function configure(): void
     {
         $this->bind()->annotatedWith(Compile::class)->toInstance(true);

--- a/src/Exception/CompileLockFailed.php
+++ b/src/Exception/CompileLockFailed.php
@@ -6,6 +6,6 @@ namespace Ray\Compiler\Exception;
 
 use RuntimeException;
 
-class CompileLockFailed extends RuntimeException implements ExceptionInterface
+final class CompileLockFailed extends RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Exception/FileNotWritable.php
+++ b/src/Exception/FileNotWritable.php
@@ -6,6 +6,6 @@ namespace Ray\Compiler\Exception;
 
 use RuntimeException;
 
-class FileNotWritable extends RuntimeException implements ExceptionInterface
+final class FileNotWritable extends RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Exception/InjectionPointUnbound.php
+++ b/src/Exception/InjectionPointUnbound.php
@@ -10,6 +10,6 @@ namespace Ray\Compiler\Exception;
  * This method is thrown if the injection point is not bound.
  * For example, when retrieving the root object.
  */
-class InjectionPointUnbound extends Unbound
+final class InjectionPointUnbound extends Unbound
 {
 }

--- a/src/Exception/InvalidInstance.php
+++ b/src/Exception/InvalidInstance.php
@@ -6,6 +6,6 @@ namespace Ray\Compiler\Exception;
 
 use LogicException;
 
-class InvalidInstance extends LogicException implements ExceptionInterface
+final class InvalidInstance extends LogicException implements ExceptionInterface
 {
 }

--- a/src/Exception/MetaNotFound.php
+++ b/src/Exception/MetaNotFound.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Ray\Compiler\Exception;
 
-class MetaNotFound extends NotCompiled implements ExceptionInterface
+final class MetaNotFound extends NotCompiled implements ExceptionInterface
 {
 }

--- a/src/Exception/ScriptDirNotReadable.php
+++ b/src/Exception/ScriptDirNotReadable.php
@@ -6,6 +6,6 @@ namespace Ray\Compiler\Exception;
 
 use RuntimeException;
 
-class ScriptDirNotReadable extends RuntimeException implements ExceptionInterface
+final class ScriptDirNotReadable extends RuntimeException implements ExceptionInterface
 {
 }

--- a/src/Exception/ScriptFileNotFound.php
+++ b/src/Exception/ScriptFileNotFound.php
@@ -6,6 +6,6 @@ namespace Ray\Compiler\Exception;
 
 use RuntimeException;
 
-class ScriptFileNotFound extends RuntimeException implements ExceptionInterface
+final class ScriptFileNotFound extends RuntimeException implements ExceptionInterface
 {
 }

--- a/src/InjectionPoint.php
+++ b/src/InjectionPoint.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ray\Compiler;
 
+use Override;
 use Ray\Aop\ReflectionClass;
 use Ray\Aop\ReflectionMethod;
 use Ray\Di\Di\Qualifier;
@@ -43,7 +44,7 @@ final class InjectionPoint implements InjectionPointInterface
     /**
      * {@inheritDoc}
      */
-    #[\Override]
+    #[Override]
     public function getParameter(): ReflectionParameter
     {
         return $this->parameter;
@@ -52,7 +53,7 @@ final class InjectionPoint implements InjectionPointInterface
     /**
      * {@inheritDoc}
      */
-    #[\Override]
+    #[Override]
     public function getMethod(): ReflectionMethod
     {
         $this->parameter = $this->getParameter();
@@ -67,7 +68,7 @@ final class InjectionPoint implements InjectionPointInterface
     /**
      * {@inheritDoc}
      */
-    #[\Override]
+    #[Override]
     public function getClass(): ReflectionClass
     {
         $class = $this->parameter->getDeclaringClass();
@@ -83,7 +84,7 @@ final class InjectionPoint implements InjectionPointInterface
      *
      * @psalm-suppress ImplementedReturnTypeMismatch
      */
-    #[\Override]
+    #[Override]
     public function getQualifiers(): array
     {
         return [$this->getQualifier()];

--- a/src/InjectionPoint.php
+++ b/src/InjectionPoint.php
@@ -43,6 +43,7 @@ final class InjectionPoint implements InjectionPointInterface
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function getParameter(): ReflectionParameter
     {
         return $this->parameter;
@@ -51,6 +52,7 @@ final class InjectionPoint implements InjectionPointInterface
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function getMethod(): ReflectionMethod
     {
         $this->parameter = $this->getParameter();
@@ -65,6 +67,7 @@ final class InjectionPoint implements InjectionPointInterface
     /**
      * {@inheritDoc}
      */
+    #[\Override]
     public function getClass(): ReflectionClass
     {
         $class = $this->parameter->getDeclaringClass();
@@ -80,6 +83,7 @@ final class InjectionPoint implements InjectionPointInterface
      *
      * @psalm-suppress ImplementedReturnTypeMismatch
      */
+    #[\Override]
     public function getQualifiers(): array
     {
         return [$this->getQualifier()];

--- a/src/InjectionPoint.php
+++ b/src/InjectionPoint.php
@@ -19,6 +19,7 @@ use function class_exists;
 /**
  * @psalm-import-type ScriptDir from Types
  * @psalm-import-type Ip from Types
+ * @psalm-import-type IpParameters from Types
  */
 final class InjectionPoint implements InjectionPointInterface
 {
@@ -80,7 +81,7 @@ final class InjectionPoint implements InjectionPointInterface
     /**
      * {@inheritDoc}
      *
-     * @return array<(object|null)>
+     * @return IpParameters
      *
      * @psalm-suppress ImplementedReturnTypeMismatch
      */

--- a/src/OverrideLazyModule.php
+++ b/src/OverrideLazyModule.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Ray\Compiler;
 
+use Override;
 use Ray\Di\AbstractModule;
 
-class OverrideLazyModule implements LazyModuleInterface
+final class OverrideLazyModule implements LazyModuleInterface
 {
     /** @var callable(): AbstractModule */
     private $modules;
@@ -21,6 +22,7 @@ class OverrideLazyModule implements LazyModuleInterface
         $this->overrideModule = $overrideModule;
     }
 
+    #[Override]
     public function __invoke(): AbstractModule
     {
         $module = ($this->modules)();

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -11,9 +11,10 @@ use function count;
 use function sprintf;
 use function str_replace;
 
+/** @psalm-import-type Scripts from Types */
 final class Scripts implements Countable
 {
-    /** @var array<string, string> */
+    /** @var Scripts */
     private $scripts = [];
 
     public function add(string $index, string $script): void

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -6,6 +6,7 @@ namespace Ray\Compiler;
 
 use Countable;
 
+use Override;
 use function count;
 use function sprintf;
 use function str_replace;
@@ -34,6 +35,7 @@ EOL;
         }
     }
 
+    #[Override]
     public function count(): int
     {
         return count($this->scripts);

--- a/src/Scripts.php
+++ b/src/Scripts.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Ray\Compiler;
 
 use Countable;
-
 use Override;
+
 use function count;
 use function sprintf;
 use function str_replace;

--- a/src/Types.php
+++ b/src/Types.php
@@ -18,6 +18,12 @@ use Ray\Di\InjectorInterface;
  * @psalm-type InjectionPoint = callable(): InjectionPoint
  * @psalm-type Injector = callable(): InjectorInterface
  * @psalm-type ScriptDirs = list<ScriptDir>
+ * @psalm-type Scripts = array<string, string>
+ * @psalm-type SavedSingletons = list<class-string>
+ * @psalm-type ConstructorParams = list<mixed>
+ * @psalm-type BindingCode = list<string>
+ * @psalm-type SetterCode = list<string>
+ * @psalm-type IpParameters = list<object|null>
  */
 final class Types
 {

--- a/vendor-bin/tools/composer.lock
+++ b/vendor-bin/tools/composer.lock
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v3.1.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "7cf7fef3d667bfe4b2560bc87e67d5387a7bcde9"
+                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/7cf7fef3d667bfe4b2560bc87e67d5387a7bcde9",
-                "reference": "7cf7fef3d667bfe4b2560bc87e67d5387a7bcde9",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
+                "reference": "fa0ab33a6f47a82929c38d03ca47ebb71086a93f",
                 "shasum": ""
             },
             "require": {
@@ -78,7 +78,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v3.1.0"
+                "source": "https://github.com/amphp/amp/tree/v3.1.1"
             },
             "funding": [
                 {
@@ -86,20 +86,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-26T16:07:39+00:00"
+            "time": "2025-08-27T21:42:00+00:00"
         },
         {
             "name": "amphp/byte-stream",
-            "version": "v2.1.1",
+            "version": "v2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/byte-stream.git",
-                "reference": "daa00f2efdbd71565bf64ffefa89e37542addf93"
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/daa00f2efdbd71565bf64ffefa89e37542addf93",
-                "reference": "daa00f2efdbd71565bf64ffefa89e37542addf93",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/55a6bd071aec26fa2a3e002618c20c35e3df1b46",
+                "reference": "55a6bd071aec26fa2a3e002618c20c35e3df1b46",
                 "shasum": ""
             },
             "require": {
@@ -153,7 +153,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/byte-stream/issues",
-                "source": "https://github.com/amphp/byte-stream/tree/v2.1.1"
+                "source": "https://github.com/amphp/byte-stream/tree/v2.1.2"
             },
             "funding": [
                 {
@@ -161,7 +161,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-02-17T04:49:38+00:00"
+            "time": "2025-03-16T17:10:27+00:00"
         },
         {
             "name": "amphp/cache",
@@ -319,16 +319,16 @@
         },
         {
             "name": "amphp/parallel",
-            "version": "v2.3.1",
+            "version": "v2.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/parallel.git",
-                "reference": "5113111de02796a782f5d90767455e7391cca190"
+                "reference": "321b45ae771d9c33a068186b24117e3cd1c48dce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/parallel/zipball/5113111de02796a782f5d90767455e7391cca190",
-                "reference": "5113111de02796a782f5d90767455e7391cca190",
+                "url": "https://api.github.com/repos/amphp/parallel/zipball/321b45ae771d9c33a068186b24117e3cd1c48dce",
+                "reference": "321b45ae771d9c33a068186b24117e3cd1c48dce",
                 "shasum": ""
             },
             "require": {
@@ -391,7 +391,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/parallel/issues",
-                "source": "https://github.com/amphp/parallel/tree/v2.3.1"
+                "source": "https://github.com/amphp/parallel/tree/v2.3.2"
             },
             "funding": [
                 {
@@ -399,7 +399,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-21T01:56:09+00:00"
+            "time": "2025-08-27T21:55:40+00:00"
         },
         {
             "name": "amphp/parser",
@@ -465,16 +465,16 @@
         },
         {
             "name": "amphp/pipeline",
-            "version": "v1.2.2",
+            "version": "v1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/pipeline.git",
-                "reference": "97cbf289f4d8877acfe58dd90ed5a4370a43caa4"
+                "reference": "7b52598c2e9105ebcddf247fc523161581930367"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/pipeline/zipball/97cbf289f4d8877acfe58dd90ed5a4370a43caa4",
-                "reference": "97cbf289f4d8877acfe58dd90ed5a4370a43caa4",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/7b52598c2e9105ebcddf247fc523161581930367",
+                "reference": "7b52598c2e9105ebcddf247fc523161581930367",
                 "shasum": ""
             },
             "require": {
@@ -520,7 +520,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/pipeline/issues",
-                "source": "https://github.com/amphp/pipeline/tree/v1.2.2"
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.3"
             },
             "funding": [
                 {
@@ -528,7 +528,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-19T15:42:46+00:00"
+            "time": "2025-03-16T16:33:53+00:00"
         },
         {
             "name": "amphp/process",
@@ -896,16 +896,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.4.3",
+            "version": "3.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12"
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
-                "reference": "4313d26ada5e0c4edfbd1dc481a92ff7bff91f12",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
                 "shasum": ""
             },
             "require": {
@@ -957,7 +957,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.3"
+                "source": "https://github.com/composer/semver/tree/3.4.4"
             },
             "funding": [
                 {
@@ -967,13 +967,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-09-19T14:15:21+00:00"
+            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -1042,6 +1038,58 @@
             "time": "2024-05-06T16:37:16+00:00"
         },
         {
+            "name": "danog/advanced-json-rpc",
+            "version": "v3.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/danog/php-advanced-json-rpc.git",
+                "reference": "aadb1c4068a88c3d0530cfe324b067920661efcb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/danog/php-advanced-json-rpc/zipball/aadb1c4068a88c3d0530cfe324b067920661efcb",
+                "reference": "aadb1c4068a88c3d0530cfe324b067920661efcb",
+                "shasum": ""
+            },
+            "require": {
+                "netresearch/jsonmapper": "^5",
+                "php": ">=8.1",
+                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
+            },
+            "replace": {
+                "felixfbecker/php-advanced-json-rpc": "^3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "AdvancedJsonRpc\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "ISC"
+            ],
+            "authors": [
+                {
+                    "name": "Felix Becker",
+                    "email": "felix.b@outlook.com"
+                },
+                {
+                    "name": "Daniil Gentili",
+                    "email": "daniil@daniil.it"
+                }
+            ],
+            "description": "A more advanced JSONRPC implementation",
+            "support": {
+                "issues": "https://github.com/danog/php-advanced-json-rpc/issues",
+                "source": "https://github.com/danog/php-advanced-json-rpc/tree/v3.2.2"
+            },
+            "time": "2025-02-14T10:55:15+00:00"
+        },
+        {
             "name": "daverandom/libdns",
             "version": "v2.1.0",
             "source": {
@@ -1087,28 +1135,28 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.0.0",
+            "version": "v1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da"
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
-                "reference": "4be43904336affa5c2f70744a348312336afd0da",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
+                "composer-plugin-api": "^2.2",
                 "php": ">=5.4",
                 "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
             },
             "require-dev": {
-                "composer/composer": "*",
+                "composer/composer": "^2.2",
                 "ext-json": "*",
                 "ext-zip": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
                 "phpcompatibility/php-compatibility": "^9.0",
                 "yoast/phpunit-polyfills": "^1.0"
             },
@@ -1128,9 +1176,9 @@
             "authors": [
                 {
                     "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
+                    "email": "opensource@frenck.dev",
+                    "homepage": "https://frenck.dev",
+                    "role": "Open source developer"
                 },
                 {
                     "name": "Contributors",
@@ -1138,7 +1186,6 @@
                 }
             ],
             "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
             "keywords": [
                 "PHPCodeSniffer",
                 "PHP_CodeSniffer",
@@ -1159,9 +1206,28 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "security": "https://github.com/PHPCSStandards/composer-installer/security/policy",
                 "source": "https://github.com/PHPCSStandards/composer-installer"
             },
-            "time": "2023-01-05T11:28:13+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
+                    "type": "thanks_dev"
+                }
+            ],
+            "time": "2025-07-17T20:45:56+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -1258,26 +1324,29 @@
         },
         {
             "name": "doctrine/deprecations",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/deprecations.git",
-                "reference": "31610dbb31faa98e6b5447b62340826f54fbc4e9"
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/31610dbb31faa98e6b5447b62340826f54fbc4e9",
-                "reference": "31610dbb31faa98e6b5447b62340826f54fbc4e9",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
+                "reference": "459c2f5dd3d6a4633d3b5f46ee2b1c40f57d3f38",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1 || ^8.0"
             },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=13"
+            },
             "require-dev": {
-                "doctrine/coding-standard": "^9 || ^12",
-                "phpstan/phpstan": "1.4.10 || 2.0.3",
+                "doctrine/coding-standard": "^9 || ^12 || ^13",
+                "phpstan/phpstan": "1.4.10 || 2.1.11",
                 "phpstan/phpstan-phpunit": "^1.0 || ^2",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12",
                 "psr/log": "^1 || ^2 || ^3"
             },
             "suggest": {
@@ -1297,54 +1366,9 @@
             "homepage": "https://www.doctrine-project.org/",
             "support": {
                 "issues": "https://github.com/doctrine/deprecations/issues",
-                "source": "https://github.com/doctrine/deprecations/tree/1.1.4"
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.5"
             },
-            "time": "2024-12-07T21:18:45+00:00"
-        },
-        {
-            "name": "felixfbecker/advanced-json-rpc",
-            "version": "v3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/felixfbecker/php-advanced-json-rpc.git",
-                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/felixfbecker/php-advanced-json-rpc/zipball/b5f37dbff9a8ad360ca341f3240dc1c168b45447",
-                "reference": "b5f37dbff9a8ad360ca341f3240dc1c168b45447",
-                "shasum": ""
-            },
-            "require": {
-                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "php": "^7.1 || ^8.0",
-                "phpdocumentor/reflection-docblock": "^4.3.4 || ^5.0.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^7.0 || ^8.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "AdvancedJsonRpc\\": "lib/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "ISC"
-            ],
-            "authors": [
-                {
-                    "name": "Felix Becker",
-                    "email": "felix.b@outlook.com"
-                }
-            ],
-            "description": "A more advanced JSONRPC implementation",
-            "support": {
-                "issues": "https://github.com/felixfbecker/php-advanced-json-rpc/issues",
-                "source": "https://github.com/felixfbecker/php-advanced-json-rpc/tree/v3.2.1"
-            },
-            "time": "2021-06-11T22:34:44+00:00"
+            "time": "2025-04-07T20:06:18+00:00"
         },
         {
             "name": "felixfbecker/language-server-protocol",
@@ -1404,16 +1428,16 @@
         },
         {
             "name": "fidry/cpu-core-counter",
-            "version": "1.2.0",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theofidry/cpu-core-counter.git",
-                "reference": "8520451a140d3f46ac33042715115e290cf5785f"
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/8520451a140d3f46ac33042715115e290cf5785f",
-                "reference": "8520451a140d3f46ac33042715115e290cf5785f",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
                 "shasum": ""
             },
             "require": {
@@ -1423,10 +1447,10 @@
                 "fidry/makefile": "^0.2.0",
                 "fidry/php-cs-fixer-config": "^1.1.2",
                 "phpstan/extension-installer": "^1.2.0",
-                "phpstan/phpstan": "^1.9.2",
-                "phpstan/phpstan-deprecation-rules": "^1.0.0",
-                "phpstan/phpstan-phpunit": "^1.2.2",
-                "phpstan/phpstan-strict-rules": "^1.4.4",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
                 "phpunit/phpunit": "^8.5.31 || ^9.5.26",
                 "webmozarts/strict-phpunit": "^7.5"
             },
@@ -1453,7 +1477,7 @@
             ],
             "support": {
                 "issues": "https://github.com/theofidry/cpu-core-counter/issues",
-                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.2.0"
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
             },
             "funding": [
                 {
@@ -1461,7 +1485,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-06T10:04:20+00:00"
+            "time": "2025-08-14T07:29:31+00:00"
         },
         {
             "name": "kelunik/certificate",
@@ -1697,16 +1721,16 @@
         },
         {
             "name": "netresearch/jsonmapper",
-            "version": "v4.5.0",
+            "version": "v5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cweiske/jsonmapper.git",
-                "reference": "8e76efb98ee8b6afc54687045e1b8dba55ac76e5"
+                "reference": "8c64d8d444a5d764c641ebe97e0e3bc72b25bf6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8e76efb98ee8b6afc54687045e1b8dba55ac76e5",
-                "reference": "8e76efb98ee8b6afc54687045e1b8dba55ac76e5",
+                "url": "https://api.github.com/repos/cweiske/jsonmapper/zipball/8c64d8d444a5d764c641ebe97e0e3bc72b25bf6c",
+                "reference": "8c64d8d444a5d764c641ebe97e0e3bc72b25bf6c",
                 "shasum": ""
             },
             "require": {
@@ -1742,22 +1766,22 @@
             "support": {
                 "email": "cweiske@cweiske.de",
                 "issues": "https://github.com/cweiske/jsonmapper/issues",
-                "source": "https://github.com/cweiske/jsonmapper/tree/v4.5.0"
+                "source": "https://github.com/cweiske/jsonmapper/tree/v5.0.0"
             },
-            "time": "2024-09-08T10:13:13+00:00"
+            "time": "2024-09-08T10:20:00+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.4.0",
+            "version": "v5.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3a454ca033b9e06b63282ce19562e892747449bb",
+                "reference": "3a454ca033b9e06b63282ce19562e892747449bb",
                 "shasum": ""
             },
             "require": {
@@ -1776,7 +1800,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -1800,9 +1824,52 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.2"
             },
-            "time": "2024-12-30T11:07:19+00:00"
+            "time": "2025-10-21T19:32:17+00:00"
+        },
+        {
+            "name": "openmetrics-php/exposition-text",
+            "version": "v0.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/openmetrics-php/exposition-text.git",
+                "reference": "4f65004f93e53eac4b9668879b92d3c200a851ba"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/openmetrics-php/exposition-text/zipball/4f65004f93e53eac4b9668879b92d3c200a851ba",
+                "reference": "4f65004f93e53eac4b9668879b92d3c200a851ba",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0 || ^8.4"
+            },
+            "require-dev": {
+                "ext-xdebug": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "OpenMetricsPhp\\Exposition\\Text\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Holger Woltersdorf",
+                    "email": "hw@hollo.me"
+                }
+            ],
+            "description": "Implementation of the text exposition format of OpenMetrics",
+            "support": {
+                "issues": "https://github.com/openmetrics-php/exposition-text/issues",
+                "source": "https://github.com/openmetrics-php/exposition-text/tree/v0.4.2"
+            },
+            "time": "2025-06-04T14:59:47+00:00"
         },
         {
             "name": "pdepend/pdepend",
@@ -1922,16 +1989,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.1",
+            "version": "5.6.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8"
+                "reference": "94f8051919d1b0369a6bcc7931d679a511c03fe9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8",
-                "reference": "e5e784149a09bd69d9a5e3b01c5cbd2e2bd653d8",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94f8051919d1b0369a6bcc7931d679a511c03fe9",
+                "reference": "94f8051919d1b0369a6bcc7931d679a511c03fe9",
                 "shasum": ""
             },
             "require": {
@@ -1980,9 +2047,9 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.1"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.3"
             },
-            "time": "2024-12-07T09:39:29+00:00"
+            "time": "2025-08-01T19:43:32+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -2127,21 +2194,22 @@
         },
         {
             "name": "phpmetrics/phpmetrics",
-            "version": "v3.0.0rc6",
+            "version": "v3.0.0rc8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpmetrics/PhpMetrics.git",
-                "reference": "6c68b4b4f863d57139cd32eee00c9bf149bf12dd"
+                "reference": "7111fe26c10092ed73c88fd325b43ddcd1b08558"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmetrics/PhpMetrics/zipball/6c68b4b4f863d57139cd32eee00c9bf149bf12dd",
-                "reference": "6c68b4b4f863d57139cd32eee00c9bf149bf12dd",
+                "url": "https://api.github.com/repos/phpmetrics/PhpMetrics/zipball/7111fe26c10092ed73c88fd325b43ddcd1b08558",
+                "reference": "7111fe26c10092ed73c88fd325b43ddcd1b08558",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "nikic/php-parser": "^5.0",
+                "nikic/php-parser": "^5.4",
+                "openmetrics-php/exposition-text": "^0.4.1",
                 "php": ">=8.1"
             },
             "replace": {
@@ -2149,17 +2217,18 @@
                 "halleck45/phpmetrics": "*"
             },
             "require-dev": {
-                "phake/phake": "^4.4.0",
-                "phpstan/extension-installer": "^1.3",
-                "phpstan/phpstan": "^1.10",
-                "phpstan/phpstan-deprecation-rules": "^1.1",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpstan/phpstan-strict-rules": "^1.5",
+                "phake/phake": "^4.5.3",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-deprecation-rules": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
                 "phpunit/phpunit": "^10.5",
                 "roave/security-advisories": "dev-latest",
                 "sebastian/comparator": ">=5.0.0",
-                "squizlabs/php_codesniffer": "^3.8",
-                "symfony/dom-crawler": "^6.4"
+                "squizlabs/php_codesniffer": "^3.11",
+                "symfony/dom-crawler": "^6.4",
+                "vimeo/psalm": "^6.3"
             },
             "suggest": {
                 "ext-dom": "To allow XML parsing and report results.",
@@ -2196,36 +2265,36 @@
             ],
             "support": {
                 "issues": "https://github.com/PhpMetrics/PhpMetrics/issues",
-                "source": "https://github.com/phpmetrics/PhpMetrics/tree/v3.0.0rc6"
+                "source": "https://github.com/phpmetrics/PhpMetrics/tree/v3.0.0rc8"
             },
-            "time": "2024-02-08T11:24:59+00:00"
+            "time": "2025-02-05T09:10:37+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.33.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "82a311fd3690fb2bf7b64d5c98f912b3dd746140"
+                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/82a311fd3690fb2bf7b64d5c98f912b3dd746140",
-                "reference": "82a311fd3690fb2bf7b64d5c98f912b3dd746140",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/1e0cd5370df5dd2e556a36b9c62f62e555870495",
+                "reference": "1e0cd5370df5dd2e556a36b9c62f62e555870495",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "doctrine/annotations": "^2.0",
-                "nikic/php-parser": "^4.15",
+                "nikic/php-parser": "^5.3.0",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "^1.5",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpstan/phpstan-strict-rules": "^1.0",
-                "phpunit/phpunit": "^9.5",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
                 "symfony/process": "^5.2"
             },
             "type": "library",
@@ -2243,22 +2312,17 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.33.0"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.0"
             },
-            "time": "2024-10-13T11:25:22+00:00"
+            "time": "2025-08-30T15:50:23+00:00"
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "7d08f569e582ade182a375c366cbd896eccadd3a"
-            },
+            "version": "2.1.31",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7d08f569e582ade182a375c366cbd896eccadd3a",
-                "reference": "7d08f569e582ade182a375c366cbd896eccadd3a",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ead89849d879fe203ce9292c6ef5e7e76f867b96",
+                "reference": "ead89849d879fe203ce9292c6ef5e7e76f867b96",
                 "shasum": ""
             },
             "require": {
@@ -2303,7 +2367,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-21T14:54:06+00:00"
+            "time": "2025-10-10T14:14:11+00:00"
         },
         {
             "name": "psr/container",
@@ -2518,16 +2582,16 @@
         },
         {
             "name": "revolt/event-loop",
-            "version": "v1.0.6",
+            "version": "v1.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/revoltphp/event-loop.git",
-                "reference": "25de49af7223ba039f64da4ae9a28ec2d10d0254"
+                "reference": "09bf1bf7f7f574453efe43044b06fafe12216eb3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/25de49af7223ba039f64da4ae9a28ec2d10d0254",
-                "reference": "25de49af7223ba039f64da4ae9a28ec2d10d0254",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/09bf1bf7f7f574453efe43044b06fafe12216eb3",
+                "reference": "09bf1bf7f7f574453efe43044b06fafe12216eb3",
                 "shasum": ""
             },
             "require": {
@@ -2584,35 +2648,35 @@
             ],
             "support": {
                 "issues": "https://github.com/revoltphp/event-loop/issues",
-                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.6"
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.7"
             },
-            "time": "2023-11-30T05:34:44+00:00"
+            "time": "2025-01-25T19:27:39+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "6.0.2",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
-                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^12.0",
+                "symfony/process": "^7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -2645,7 +2709,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
             },
             "funding": [
                 {
@@ -2653,36 +2717,36 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T04:53:05+00:00"
+            "time": "2025-02-07T04:55:46+00:00"
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.15.0",
+            "version": "8.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "7d1d957421618a3803b593ec31ace470177d7817"
+                "reference": "1dd80bf3b93692bedb21a6623c496887fad05fec"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/7d1d957421618a3803b593ec31ace470177d7817",
-                "reference": "7d1d957421618a3803b593ec31ace470177d7817",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/1dd80bf3b93692bedb21a6623c496887fad05fec",
+                "reference": "1dd80bf3b93692bedb21a6623c496887fad05fec",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
-                "php": "^7.2 || ^8.0",
-                "phpstan/phpdoc-parser": "^1.23.1",
-                "squizlabs/php_codesniffer": "^3.9.0"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.1.2",
+                "php": "^7.4 || ^8.0",
+                "phpstan/phpdoc-parser": "^2.3.0",
+                "squizlabs/php_codesniffer": "^3.13.4"
             },
             "require-dev": {
-                "phing/phing": "2.17.4",
-                "php-parallel-lint/php-parallel-lint": "1.3.2",
-                "phpstan/phpstan": "1.10.60",
-                "phpstan/phpstan-deprecation-rules": "1.1.4",
-                "phpstan/phpstan-phpunit": "1.3.16",
-                "phpstan/phpstan-strict-rules": "1.5.2",
-                "phpunit/phpunit": "8.5.21|9.6.8|10.5.11"
+                "phing/phing": "3.0.1|3.1.0",
+                "php-parallel-lint/php-parallel-lint": "1.4.0",
+                "phpstan/phpstan": "2.1.24",
+                "phpstan/phpstan-deprecation-rules": "2.0.3",
+                "phpstan/phpstan-phpunit": "2.0.7",
+                "phpstan/phpstan-strict-rules": "2.0.6",
+                "phpunit/phpunit": "9.6.8|10.5.48|11.4.4|11.5.36|12.3.10"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -2706,7 +2770,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.15.0"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.22.1"
             },
             "funding": [
                 {
@@ -2718,7 +2782,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-03-09T15:20:58+00:00"
+            "time": "2025-09-13T08:53:30+00:00"
         },
         {
             "name": "spatie/array-to-xml",
@@ -2790,16 +2854,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.11.3",
+            "version": "3.13.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10"
+                "reference": "ad545ea9c1b7d270ce0fc9cbfb884161cd706119"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10",
-                "reference": "ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ad545ea9c1b7d270ce0fc9cbfb884161cd706119",
+                "reference": "ad545ea9c1b7d270ce0fc9cbfb884161cd706119",
                 "shasum": ""
             },
             "require": {
@@ -2866,24 +2930,24 @@
                     "type": "open_collective"
                 },
                 {
-                    "url": "https://thanks.dev/phpcsstandards",
+                    "url": "https://thanks.dev/u/gh/phpcsstandards",
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-01-23T17:04:15+00:00"
+            "time": "2025-09-05T05:47:09+00:00"
         },
         {
             "name": "symfony/config",
-            "version": "v7.2.3",
+            "version": "v7.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "7716594aaae91d9141be080240172a92ecca4d44"
+                "reference": "8a09223170046d2cfda3d2e11af01df2c641e961"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/7716594aaae91d9141be080240172a92ecca4d44",
-                "reference": "7716594aaae91d9141be080240172a92ecca4d44",
+                "url": "https://api.github.com/repos/symfony/config/zipball/8a09223170046d2cfda3d2e11af01df2c641e961",
+                "reference": "8a09223170046d2cfda3d2e11af01df2c641e961",
                 "shasum": ""
             },
             "require": {
@@ -2929,7 +2993,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v7.2.3"
+                "source": "https://github.com/symfony/config/tree/v7.3.4"
             },
             "funding": [
                 {
@@ -2941,31 +3005,36 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-22T12:07:01+00:00"
+            "time": "2025-09-22T12:46:16+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.2.1",
+            "version": "v7.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "fefcc18c0f5d0efe3ab3152f15857298868dc2c3"
+                "reference": "2b9c5fafbac0399a20a2e82429e2bd735dcfb7db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/fefcc18c0f5d0efe3ab3152f15857298868dc2c3",
-                "reference": "fefcc18c0f5d0efe3ab3152f15857298868dc2c3",
+                "url": "https://api.github.com/repos/symfony/console/zipball/2b9c5fafbac0399a20a2e82429e2bd735dcfb7db",
+                "reference": "2b9c5fafbac0399a20a2e82429e2bd735dcfb7db",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^6.4|^7.0"
+                "symfony/string": "^7.2"
             },
             "conflict": {
                 "symfony/dependency-injection": "<6.4",
@@ -3022,7 +3091,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.2.1"
+                "source": "https://github.com/symfony/console/tree/v7.3.4"
             },
             "funding": [
                 {
@@ -3034,24 +3103,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-11T03:49:26+00:00"
+            "time": "2025-09-22T15:31:00+00:00"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v7.2.3",
+            "version": "v7.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "1d321c4bc3fe926fd4c38999a4c9af4f5d61ddfc"
+                "reference": "82119812ab0bf3425c1234d413efd1b19bb92ae4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/1d321c4bc3fe926fd4c38999a4c9af4f5d61ddfc",
-                "reference": "1d321c4bc3fe926fd4c38999a4c9af4f5d61ddfc",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/82119812ab0bf3425c1234d413efd1b19bb92ae4",
+                "reference": "82119812ab0bf3425c1234d413efd1b19bb92ae4",
                 "shasum": ""
             },
             "require": {
@@ -3059,7 +3132,7 @@
                 "psr/container": "^1.1|^2.0",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/service-contracts": "^3.5",
-                "symfony/var-exporter": "^6.4|^7.0"
+                "symfony/var-exporter": "^6.4.20|^7.2.5"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2",
@@ -3102,7 +3175,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v7.2.3"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.3.4"
             },
             "funding": [
                 {
@@ -3114,24 +3187,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-17T10:56:55+00:00"
+            "time": "2025-09-11T10:12:26+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
-                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
                 "shasum": ""
             },
             "require": {
@@ -3144,7 +3221,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -3169,7 +3246,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -3185,20 +3262,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.2.0",
+            "version": "v7.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "b8dce482de9d7c9fe2891155035a7248ab5c7fdb"
+                "reference": "edcbb768a186b5c3f25d0643159a787d3e63b7fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b8dce482de9d7c9fe2891155035a7248ab5c7fdb",
-                "reference": "b8dce482de9d7c9fe2891155035a7248ab5c7fdb",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/edcbb768a186b5c3f25d0643159a787d3e63b7fd",
+                "reference": "edcbb768a186b5c3f25d0643159a787d3e63b7fd",
                 "shasum": ""
             },
             "require": {
@@ -3235,7 +3312,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.2.0"
+                "source": "https://github.com/symfony/filesystem/tree/v7.3.2"
             },
             "funding": [
                 {
@@ -3247,15 +3324,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-25T15:15:23+00:00"
+            "time": "2025-07-07T08:17:47+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.31.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -3314,7 +3395,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -3326,6 +3407,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -3334,16 +3419,16 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.31.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe"
+                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
-                "reference": "b9123926e3b7bc2f98c02ad54f6a4b02b91a8abe",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
                 "shasum": ""
             },
             "require": {
@@ -3392,7 +3477,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -3404,15 +3489,19 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2025-06-27T09:58:17+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.31.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -3473,7 +3562,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -3485,6 +3574,10 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
@@ -3493,19 +3586,20 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.31.0",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
-                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
                 "shasum": ""
             },
             "require": {
+                "ext-iconv": "*",
                 "php": ">=7.2"
             },
             "provide": {
@@ -3553,7 +3647,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
             },
             "funding": [
                 {
@@ -3565,24 +3659,108 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2024-12-23T08:48:59+00:00"
         },
         {
-            "name": "symfony/service-contracts",
-            "version": "v3.5.1",
+            "name": "symfony/polyfill-php84",
+            "version": "v1.33.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0"
+                "url": "https://github.com/symfony/polyfill-php84.git",
+                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
-                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/d8ced4d875142b6a7426000426b8abc631d6b191",
+                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php84\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.4+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.33.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-06-24T13:30:11+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
+                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
                 "shasum": ""
             },
             "require": {
@@ -3600,7 +3778,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -3636,7 +3814,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -3652,20 +3830,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2025-04-25T09:37:31+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.2.0",
+            "version": "v7.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "446e0d146f991dde3e73f45f2c97a9faad773c82"
+                "reference": "f96476035142921000338bad71e5247fbc138872"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/446e0d146f991dde3e73f45f2c97a9faad773c82",
-                "reference": "446e0d146f991dde3e73f45f2c97a9faad773c82",
+                "url": "https://api.github.com/repos/symfony/string/zipball/f96476035142921000338bad71e5247fbc138872",
+                "reference": "f96476035142921000338bad71e5247fbc138872",
                 "shasum": ""
             },
             "require": {
@@ -3680,7 +3858,6 @@
             },
             "require-dev": {
                 "symfony/emoji": "^7.1",
-                "symfony/error-handler": "^6.4|^7.0",
                 "symfony/http-client": "^6.4|^7.0",
                 "symfony/intl": "^6.4|^7.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
@@ -3723,7 +3900,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.2.0"
+                "source": "https://github.com/symfony/string/tree/v7.3.4"
             },
             "funding": [
                 {
@@ -3735,28 +3912,33 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-13T13:31:26+00:00"
+            "time": "2025-09-11T14:36:48+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.2.0",
+            "version": "v7.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "1a6a89f95a46af0f142874c9d650a6358d13070d"
+                "reference": "0f020b544a30a7fe8ba972e53ee48a74c0bc87f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/1a6a89f95a46af0f142874c9d650a6358d13070d",
-                "reference": "1a6a89f95a46af0f142874c9d650a6358d13070d",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/0f020b544a30a7fe8ba972e53ee48a74c0bc87f4",
+                "reference": "0f020b544a30a7fe8ba972e53ee48a74c0bc87f4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "require-dev": {
                 "symfony/property-access": "^6.4|^7.0",
@@ -3799,7 +3981,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.2.0"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.3.4"
             },
             "funding": [
                 {
@@ -3811,24 +3993,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-18T07:58:17+00:00"
+            "time": "2025-09-11T10:12:26+00:00"
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.2.0",
+            "version": "6.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "814dfde37b43a1fe6d9b0996e08b19661af53bc5"
+                "reference": "1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/814dfde37b43a1fe6d9b0996e08b19661af53bc5",
-                "reference": "814dfde37b43a1fe6d9b0996e08b19661af53bc5",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51",
+                "reference": "1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51",
                 "shasum": ""
             },
             "require": {
@@ -3838,6 +4024,7 @@
                 "composer-runtime-api": "^2",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "composer/xdebug-handler": "^2.0 || ^3.0",
+                "danog/advanced-json-rpc": "^3.1",
                 "dnoegel/php-xdg-base-dir": "^0.1.1",
                 "ext-ctype": "*",
                 "ext-dom": "*",
@@ -3846,16 +4033,16 @@
                 "ext-mbstring": "*",
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
-                "felixfbecker/advanced-json-rpc": "^3.1",
                 "felixfbecker/language-server-protocol": "^1.5.3",
                 "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1 || ^1.0.0",
-                "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "netresearch/jsonmapper": "^5.0",
                 "nikic/php-parser": "^5.0.0",
-                "php": "~8.1.17 || ~8.2.4 || ~8.3.0 || ~8.4.0",
-                "sebastian/diff": "^4.0 || ^5.0 || ^6.0",
+                "php": "~8.1.31 || ~8.2.27 || ~8.3.16 || ~8.4.3",
+                "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0",
                 "spatie/array-to-xml": "^2.17.0 || ^3.0",
                 "symfony/console": "^6.0 || ^7.0",
-                "symfony/filesystem": "^6.0 || ^7.0"
+                "symfony/filesystem": "~6.3.12 || ~6.4.3 || ^7.0.3",
+                "symfony/polyfill-php84": "^1.31.0"
             },
             "provide": {
                 "psalm/psalm": "self.version"
@@ -3864,6 +4051,7 @@
                 "amphp/phpunit-util": "^3",
                 "bamarni/composer-bin-plugin": "^1.4",
                 "brianium/paratest": "^6.9",
+                "danog/class-finder": "^0.4.8",
                 "dg/bypass-finals": "^1.5",
                 "ext-curl": "*",
                 "mockery/mockery": "^1.5",
@@ -3886,6 +4074,7 @@
                 "psalm-language-server",
                 "psalm-plugin",
                 "psalm-refactor",
+                "psalm-review",
                 "psalter"
             ],
             "type": "project",
@@ -3930,32 +4119,32 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2025-02-01T16:30:21+00:00"
+            "time": "2025-08-06T10:10:28+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.11.0",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
+                "reference": "541057574806f942c94662b817a50f63f7345360"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/541057574806f942c94662b817a50f63f7345360",
+                "reference": "541057574806f942c94662b817a50f63f7345360",
                 "shasum": ""
             },
             "require": {
                 "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
                 "php": "^7.2 || ^8.0"
             },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<4.6.1 || 4.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.13"
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
             },
             "type": "library",
             "extra": {
@@ -3986,9 +4175,9 @@
             ],
             "support": {
                 "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
+                "source": "https://github.com/webmozarts/assert/tree/1.12.0"
             },
-            "time": "2022-06-03T18:03:27+00:00"
+            "time": "2025-10-20T12:43:39+00:00"
         }
     ],
     "aliases": [],


### PR DESCRIPTION
## Summary
- Add PHP 8.5 to continuous integration test matrix
- Move PHP 8.4 to `old_stable` versions
- Set `current_stable` to 8.5

## Changes
- Updated `.github/workflows/continuous-integration.yml`

## Notes
- No `composer.json` changes needed as `^8.0` requirement already covers PHP 8.5
- This ensures compatibility testing with the latest PHP version

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce Code4Dependency class for dependency code generation, refactor DependencyCode and DiCompiler to use it, and update CI matrix to include PHP 8.5

Enhancements:
- Extract dependency code generation into a new Code4Dependency class and integrate it into DependencyCode
- Refactor DiCompiler to invoke Code4Dependency with updated constructor and streamline container property handling

CI:
- Add PHP 8.5 to the continuous integration matrix and move PHP 8.4 to old_stable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to support PHP 8.4 and 8.5
  * Added PHP 8.3 polyfill for broader compatibility
  * Applied override attributes across the codebase for improved static analysis and IDE support
  * Marked several internal and exception classes as final to improve stability
  * Added deprecation annotation to a legacy helper

* **Documentation**
  * Enhanced static-analysis type aliases and excluded deprecated code from scans
<!-- end of auto-generated comment: release notes by coderabbit.ai -->