### PR TITLE
Add LLM documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,150 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Ray.Compiler is a dependency injection compiler for Ray.Di that pre-compiles DI bindings into executable PHP code. It transforms Ray.Di's complex dependency resolution into simple PHP scripts, replacing the full-featured Ray.Di Injector with a minimal `CompiledInjector` that does nothing but execute pre-compiled code.
+
+**Two-Phase Architecture:**
+- **Compile-time**: Uses Ray.Di's full dependency resolution (reflection, binding analysis, AOP weaving)
+- **Runtime**: Minimal `CompiledInjector` simply executes pre-generated scripts—no reflection, no binding resolution, no dependency graph traversal
+
+## Prerequisites
+
+Understanding Ray.Compiler requires understanding Ray.Di (the dependency injection framework being compiled).
+
+**Ray.Di Complete Documentation (for LLMs):**
+https://ray-di.github.io/llms-full.txt
+
+This document explains Ray.Di's module system, dependency resolution, scope management, and AOP—all concepts that Ray.Compiler transforms into executable PHP code at compile-time, allowing runtime to use the minimal CompiledInjector instead of Ray.Di's full Injector.
+
+## Core Architecture
+
+### Compilation Flow
+
+1. **Compiler** (`src/Compiler.php`): Entry point that compiles Ray.Di modules into Scripts
+   - Acquires file lock for thread safety during compilation
+   - Uses ContainerFactory to create dependency container
+   - Uses CompileVisitor to traverse and convert dependencies to PHP code
+   - Saves compiled scripts to target directory via Scripts class
+
+2. **CompileVisitor** (`src/CompileVisitor.php`): Implements visitor pattern to traverse dependency graph
+   - Visits dependencies, providers, instances, AOP bindings
+   - Delegates to InstanceScript for code generation
+   - Distinguishes between singleton and prototype scopes
+
+3. **InstanceScript** (`src/InstanceScript.php`): Generates PHP code for dependency instantiation
+   - Handles constructor injection via `pushClass()`
+   - Handles setter injection via `pushMethod()`
+   - Handles AOP bindings via `pushAspectBind()`
+   - Manages context for provider bindings
+   - Generates final script with proper scope handling
+
+4. **Code4Dependency** (`src/Code4Dependency.php`): Alternative code generation approach
+   - Uses PrivateProperty to access internal dependency state
+   - Generates code for constructor args, setters, and AOP bindings
+   - Recently introduced to handle dependency code generation
+
+5. **Scripts** (`src/Scripts.php`): Container for generated scripts
+   - Stores script index -> PHP code mapping
+   - Writes scripts to files named by dependency index (e.g., `Interface-name.php`)
+
+### Runtime Execution
+
+1. **CompiledInjector** (`src/CompiledInjector.php`): Minimal injector that executes pre-compiled code
+   - **Does NOT perform dependency resolution** - all resolution happens at compile-time
+   - **Does NOT use reflection** - all necessary metadata embedded in compiled scripts
+   - `getInstance()` simply constructs file path and executes script via `require`
+   - Manages singleton instances in `$singletons` array (passed by reference to scripts)
+   - Registers autoloader for compiled classes
+   - Script files named as: `ClassName-bindingName.php`
+   - This minimal approach eliminates all Ray.Di runtime overhead
+
+2. **Scope Functions** (`src-function/`): Helper functions used in compiled scripts
+   - `singleton()`: Returns cached instance or requires script file (singleton scope)
+   - `prototype()`: Always requires script file for new instance (prototype scope)
+   - Both use `$scriptDir`, `$singletons`, `$dependencyIndex`, and optional `$ip` (injection point)
+
+### Directory Structure
+
+- `src/`: Main source code
+- `src-deprecated/`: Legacy code maintained for backwards compatibility
+- `src-function/`: Global functions for singleton/prototype scope handling
+- `tests/`: PHPUnit tests with `tests/Fake/` for test fixtures
+- Compiled scripts output to user-specified directory (e.g., `tmp/di/`, `.di/`)
+
+## Development Commands
+
+### Testing
+```bash
+# Run tests
+composer test
+
+# Run tests with coverage (pcov)
+composer pcov
+
+# Run all tests, CS, and static analysis
+composer tests
+```
+
+### Code Quality
+```bash
+# Check coding standards
+composer cs
+
+# Fix coding standards
+composer cs-fix
+
+# Run static analysis (Psalm + PHPStan)
+composer sa
+
+# Clean caches
+composer clean
+```
+
+### Full Build
+```bash
+# Run complete build with metrics
+composer build
+```
+
+### Running Single Tests
+```bash
+# Run specific test class
+vendor/bin/phpunit tests/CompilerTest.php
+
+# Run specific test method
+vendor/bin/phpunit --filter testMethodName tests/CompilerTest.php
+```
+
+## Key Concepts
+
+### Dependency Index Format
+Dependencies are identified as `Interface-BindingName` (e.g., `FooInterface-`, `BarInterface-named`). The `-ANY` suffix is used for unnamed bindings. This index is used for:
+- Script file naming (with backslashes replaced by underscores)
+- Singleton storage keys
+- Dependency lookups
+
+### Injection Points
+When a dependency requires injection point information, the compiled code includes `$ip` array with:
+- `[0]`: Declaring class name
+- `[1]`: Declaring method/function name
+- `[2]`: Parameter name
+
+InjectionPoint class reconstructs ReflectionParameter from this array.
+
+### Scope Handling
+- **Singleton**: Instance created once, cached in `$singletons[$dependencyIndex]`
+- **Prototype**: New instance created on each `getInstance()` call
+- Scope determined during compilation and embedded in generated scripts
+
+### AOP (Aspect-Oriented Programming)
+- Bindings stored in `$instance->bindings` array: `['methodName' => [interceptor1, interceptor2]]`
+- Interceptors are themselves dependencies loaded via `singleton()` with `-` suffix
+
+## PHP Version Support
+Requires PHP 7.2+ or 8.0+. Code uses both annotations and attributes (PHP 8 attributes via `#[...]` syntax).
+
+## Compiled Output Should Not Be Committed
+The `/tmp/di/` or similar compiled script directories should be in `.gitignore`. Compilation happens during deployment/build, not development.

--- a/README.md
+++ b/README.md
@@ -73,96 +73,6 @@ Add compile script to your `composer.json`:
 }
 ```
 
-## Docker Integration
-
-Use multi-stage builds to maintain path consistency:
-
-```dockerfile
-# Build stage
-FROM php:8.2-cli-alpine as builder
-
-# Set working directory
-WORKDIR /app
-
-# Install composer
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
-
-# Copy composer files first
-COPY composer.json composer.lock ./
-
-# Install dependencies
-RUN composer install \
-    --no-dev \
-    --no-scripts \
-    --prefer-dist \
-    --no-interaction \
-    --optimize-autoloader
-
-# Copy application code
-COPY . .
-
-# Create non-root user
-RUN adduser -D appuser
-USER appuser
-
-# Compile DI code
-RUN php bin/compile.php
-
-# Production stage
-FROM php:8.2-cli-alpine
-
-# Create non-root user
-RUN adduser -D appuser
-
-# Set working directory
-WORKDIR /app
-
-# Copy only necessary files from builder
-COPY --from=builder /app/vendor/ ./vendor/
-COPY . .
-COPY --from=builder /app/tmp/di/ ./tmp/di/
-
-# Switch to non-root user
-USER appuser
-# Start command or other configurations can be added here
-```
-
-## Docker Best Practices
-
-When building your Docker images, it’s important to exclude unnecessary files to speed up builds, reduce image size, and prevent sensitive files from being included in the image. Below is a recommended `.dockerignore` file. Adjust it to fit your project’s requirements:
-
-```dockerignore
-# Ignore Git files
-.git/
-
-# Ignore dependency directories
-/vendor/
-/node_modules/
-
-# Ignore compiled DI files
-/tmp/di/
-
-# Ignore environment-specific files
-.env
-.env.local
-.env.*.local
-
-# Ignore documentation and tests
-/docs/
-/tests/
-
-# Ignore IDE-specific files
-.idea/
-.vscode/
-
-# Ignore log files
-*.log
-
-# Ignore OS-specific files
-.DS_Store
-Thumbs.db
-```
-
 ## Version Control
 
 Compiled DI code is considered an environment-specific build artifact and **should not** be committed to version control. This approach ensures that your repository remains clean and build artifacts do not cause merge conflicts or unexpected behavior across different environments.
@@ -172,3 +82,9 @@ Add the compile directory to your `.gitignore`:
 ```gitignore
 /tmp/di/
 ```
+
+## Documentation
+
+- **[LLM Documentation](https://ray-di.github.io/Ray.Compiler/llms.txt)** - Brief documentation optimized for LLMs
+- **[Complete LLM Documentation](https://ray-di.github.io/Ray.Compiler/llms-full.txt)** - Full documentation with architecture details
+

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -1,0 +1,249 @@
+Ray.Compiler - DI Compiler for Ray.Di - Complete Documentation
+====================================================================
+
+Project Overview
+----------------
+
+Ray.Compiler is a dependency injection compiler for Ray.Di that pre-compiles DI bindings into executable PHP code. It transforms Ray.Di's complex dependency resolution into simple PHP scripts, replacing the full-featured Ray.Di Injector with a minimal CompiledInjector that does nothing but execute pre-compiled code.
+
+Two-Phase Architecture:
+- Compile-time: Uses Ray.Di's full dependency resolution (reflection, binding analysis, AOP weaving)
+- Runtime: Minimal CompiledInjector simply executes pre-generated scripts—no reflection, no binding resolution, no dependency graph traversal
+
+Installation
+------------
+composer require ray/compiler
+
+Prerequisites
+-------------
+
+Understanding Ray.Compiler requires understanding Ray.Di (the dependency injection framework being compiled).
+
+Ray.Di Complete Documentation (for LLMs):
+https://ray-di.github.io/llms-full.txt
+
+This document explains Ray.Di's module system, dependency resolution, scope management, and AOP—all concepts that Ray.Compiler transforms into executable PHP code at compile-time, allowing runtime to use the minimal CompiledInjector instead of Ray.Di's full Injector.
+
+Core Architecture
+-----------------
+
+Compilation Flow
+~~~~~~~~~~~~~~~~
+
+1. Compiler (src/Compiler.php): Entry point that compiles Ray.Di modules into Scripts
+   - Acquires file lock for thread safety during compilation
+   - Uses ContainerFactory to create dependency container
+   - Uses CompileVisitor to traverse and convert dependencies to PHP code
+   - Saves compiled scripts to target directory via Scripts class
+
+2. CompileVisitor (src/CompileVisitor.php): Implements visitor pattern to traverse dependency graph
+   - Visits dependencies, providers, instances, AOP bindings
+   - Delegates to InstanceScript for code generation
+   - Distinguishes between singleton and prototype scopes
+
+3. InstanceScript (src/InstanceScript.php): Generates PHP code for dependency instantiation
+   - Handles constructor injection via pushClass()
+   - Handles setter injection via pushMethod()
+   - Handles AOP bindings via pushAspectBind()
+   - Manages context for provider bindings
+   - Generates final script with proper scope handling
+
+4. Code4Dependency (src-deprecated/Code4Dependency.php): Alternative code generation approach (deprecated)
+   - Uses PrivateProperty to access internal dependency state
+   - Generates code for constructor args, setters, and AOP bindings
+   - Recently moved to deprecated directory
+
+5. Scripts (src/Scripts.php): Container for generated scripts
+   - Stores script index -> PHP code mapping
+   - Writes scripts to files named by dependency index (e.g., Interface-name.php)
+
+Runtime Execution
+~~~~~~~~~~~~~~~~~
+
+1. CompiledInjector (src/CompiledInjector.php): Minimal injector that executes pre-compiled code
+   - Does NOT perform dependency resolution - all resolution happens at compile-time
+   - Does NOT use reflection - all necessary metadata embedded in compiled scripts
+   - getInstance() simply constructs file path and executes script via require
+   - Manages singleton instances in $singletons array (passed by reference to scripts)
+   - Registers autoloader for compiled classes
+   - Script files named as: ClassName-bindingName.php
+   - This minimal approach eliminates all Ray.Di runtime overhead
+
+2. Scope Functions (src-function/): Helper functions used in compiled scripts
+   - singleton(): Returns cached instance or requires script file (singleton scope)
+   - prototype(): Always requires script file for new instance (prototype scope)
+   - Both use $scriptDir, $singletons, $dependencyIndex, and optional $ip (injection point)
+
+Directory Structure
+~~~~~~~~~~~~~~~~~~~
+
+- src/: Main source code
+- src-deprecated/: Legacy code maintained for backwards compatibility
+- src-function/: Global functions for singleton/prototype scope handling
+- tests/: PHPUnit tests with tests/Fake/ for test fixtures
+- Compiled scripts output to user-specified directory (e.g., tmp/di/, .di/)
+
+Usage
+-----
+
+Basic Usage
+~~~~~~~~~~~
+
+Pre-compile your dependencies:
+
+```php
+use Ray\Compiler\Compiler;
+
+$compiler = new Compiler();
+// Compile Ray.Di bindings to PHP files
+$compiler->compile(
+    $module,    // AbstractModule: Your application's module
+    $scriptDir  // string: Directory path where compiled PHP files will be generated
+);
+```
+
+Use the compiled injector:
+
+```php
+use Ray\Compiler\CompiledInjector;
+
+$injector = new CompiledInjector($scriptDir);
+$instance = $injector->getInstance(YourInterface::class);
+```
+
+Compiler Integration
+~~~~~~~~~~~~~~~~~~~~
+
+Create a compile script:
+
+```php
+try {
+    $scripts = (new Compiler())->compile(
+        new AppModule(),
+        __DIR__ . '/di'
+    );
+    printf("Compiled %d files.\n", count($scripts));
+} catch (CompileException $e) {
+    fprintf(STDERR, "Compilation failed: %s\n", $e->getMessage());
+    exit(1);
+}
+```
+
+Add compile script to your composer.json:
+
+```json
+{
+    "scripts": {
+        "post-install-cmd": ["php bin/compile.php"]
+    }
+}
+```
+
+Deployment
+----------
+
+Compiled DI code must be generated during build/deployment, not during development. This ensures path consistency across environments.
+
+For Docker deployments, use multi-stage builds where compilation happens in the build stage and compiled scripts are copied to the production stage. See README.md for detailed Docker configuration examples.
+
+Version Control
+---------------
+
+Compiled DI code is considered an environment-specific build artifact and should NOT be committed to version control. This approach ensures that your repository remains clean and build artifacts do not cause merge conflicts or unexpected behavior across different environments.
+
+Add the compile directory to your .gitignore:
+
+```gitignore
+/tmp/di/
+```
+
+Development
+-----------
+
+Testing
+~~~~~~~
+
+# Run tests
+composer test
+
+# Run tests with coverage (pcov)
+composer pcov
+
+# Run all tests, CS, and static analysis
+composer tests
+
+Code Quality
+~~~~~~~~~~~~
+
+# Check coding standards
+composer cs
+
+# Fix coding standards
+composer cs-fix
+
+# Run static analysis (Psalm + PHPStan)
+composer sa
+
+# Clean caches
+composer clean
+
+Full Build
+~~~~~~~~~~
+
+# Run complete build with metrics
+composer build
+
+Running Single Tests
+~~~~~~~~~~~~~~~~~~~~
+
+# Run specific test class
+vendor/bin/phpunit tests/CompilerTest.php
+
+# Run specific test method
+vendor/bin/phpunit --filter testMethodName tests/CompilerTest.php
+
+Key Concepts
+------------
+
+Dependency Index Format
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Dependencies are identified as "Interface-BindingName" (e.g., "FooInterface-", "BarInterface-named"). The "-ANY" suffix is used for unnamed bindings. This index is used for:
+- Script file naming (with backslashes replaced by underscores)
+- Singleton storage keys
+- Dependency lookups
+
+Injection Points
+~~~~~~~~~~~~~~~~
+
+When a dependency requires injection point information, the compiled code includes $ip array with:
+- [0]: Declaring class name
+- [1]: Declaring method/function name
+- [2]: Parameter name
+
+InjectionPoint class reconstructs ReflectionParameter from this array.
+
+Scope Handling
+~~~~~~~~~~~~~~
+
+- Singleton: Instance created once, cached in $singletons[$dependencyIndex]
+- Prototype: New instance created on each getInstance() call
+- Scope determined during compilation and embedded in generated scripts
+
+AOP (Aspect-Oriented Programming)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- Bindings stored in $instance->bindings array: ['methodName' => [interceptor1, interceptor2]]
+- Interceptors are themselves dependencies loaded via singleton() with - suffix
+
+PHP Version Support
+-------------------
+
+Requires PHP 7.2+ or 8.0+. Code uses both annotations and attributes (PHP 8 attributes via #[...] syntax).
+
+Related Documentation
+---------------------
+
+- Ray.Di Documentation: https://ray-di.github.io/llms-full.txt
+- Ray.Compiler GitHub: https://github.com/ray-di/Ray.Compiler
+- Ray.Di GitHub: https://github.com/ray-di/Ray.Di

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,93 @@
+Ray.Compiler - DI Compiler for Ray.Di
+========================================
+
+Ray.Compiler is a dependency injection compiler for Ray.Di that pre-compiles DI bindings into executable PHP code. It transforms Ray.Di's complex dependency resolution into simple PHP scripts, replacing the full-featured Ray.Di Injector with a minimal CompiledInjector that does nothing but execute pre-compiled code.
+
+Installation
+------------
+composer require ray/compiler
+
+Prerequisites
+-------------
+Understanding Ray.Compiler requires understanding Ray.Di (the dependency injection framework being compiled).
+
+Ray.Di Complete Documentation (for LLMs):
+https://ray-di.github.io/llms-full.txt
+
+This document explains Ray.Di's module system, dependency resolution, scope management, and AOP—all concepts that Ray.Compiler transforms into executable PHP code.
+
+Two-Phase Architecture
+----------------------
+- Compile-time: Uses Ray.Di's full dependency resolution (reflection, binding analysis, AOP weaving)
+- Runtime: Minimal CompiledInjector simply executes pre-generated scripts—no reflection, no binding resolution, no dependency graph traversal
+
+Basic Usage
+-----------
+Pre-compile your dependencies:
+
+```php
+use Ray\Compiler\Compiler;
+
+$compiler = new Compiler();
+$compiler->compile(
+    $module,    // AbstractModule: Your application's module
+    $scriptDir  // string: Directory path where compiled PHP files will be generated
+);
+```
+
+Use the compiled injector:
+
+```php
+use Ray\Compiler\CompiledInjector;
+
+$injector = new CompiledInjector($scriptDir);
+$instance = $injector->getInstance(YourInterface::class);
+```
+
+Core Components
+---------------
+
+1. Compiler (src/Compiler.php): Entry point that compiles Ray.Di modules into Scripts
+   - Acquires file lock for thread safety during compilation
+   - Uses CompileVisitor to traverse and convert dependencies to PHP code
+   - Saves compiled scripts to target directory
+
+2. CompiledInjector (src/CompiledInjector.php): Minimal injector that executes pre-compiled code
+   - Does NOT perform dependency resolution - all resolution happens at compile-time
+   - Does NOT use reflection - all necessary metadata embedded in compiled scripts
+   - getInstance() simply constructs file path and executes script via require
+   - Manages singleton instances in $singletons array
+
+3. Scope Functions (src-function/):
+   - singleton(): Returns cached instance or requires script file (singleton scope)
+   - prototype(): Always requires script file for new instance (prototype scope)
+
+Key Concepts
+------------
+
+Dependency Index Format:
+Dependencies are identified as "Interface-BindingName" (e.g., "FooInterface-", "BarInterface-named"). This index is used for:
+- Script file naming (with backslashes replaced by underscores)
+- Singleton storage keys
+- Dependency lookups
+
+Scope Handling:
+- Singleton: Instance created once, cached in $singletons[$dependencyIndex]
+- Prototype: New instance created on each getInstance() call
+- Scope determined during compilation and embedded in generated scripts
+
+Version Control
+---------------
+Compiled DI code is considered an environment-specific build artifact and should NOT be committed to version control.
+
+Add the compile directory to your .gitignore:
+/tmp/di/
+
+PHP Version Support
+-------------------
+Requires PHP 7.2+ or 8.0+
+
+Full Documentation
+------------------
+For complete documentation including architecture details, development commands, and Docker integration, see:
+https://ray-di.github.io/Ray.Compiler/llms-full.txt


### PR DESCRIPTION
## Summary
- Add CLAUDE.md for Claude Code guidance when working with this repository
- Add docs/llms.txt for brief LLM-optimized documentation
- Add docs/llms-full.txt for complete LLM-optimized documentation with architecture details
- Add documentation links to README.md
- Remove Docker Integration section from README.md (too specific for a library)

## Changes
- **CLAUDE.md**: Comprehensive guidance for Claude Code including project overview, architecture, development commands, and key concepts
- **docs/llms.txt**: Brief documentation for quick reference
- **docs/llms-full.txt**: Complete documentation with compilation flow, runtime execution, development workflow, and all key concepts
- **README.md**: Add links to LLM documentation, remove Docker-specific sections

## Documentation Coverage
- Two-phase architecture (compile-time vs runtime)
- Core components (Compiler, CompileVisitor, InstanceScript, Scripts, CompiledInjector)
- Development commands and workflow
- Key concepts (dependency index, injection points, scopes, AOP)
- Deployment considerations

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add comprehensive LLM-specific guidance and optimized documentation files, and streamline the README by linking to these docs and removing the Docker Integration section.

New Features:
- Add LLM-optimized documentation including CLAUDE.md, brief (docs/llms.txt) and full (docs/llms-full.txt) guides

Documentation:
- Update README to link to the new LLM documentation and remove the Docker Integration section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation covering Ray.Compiler architecture, core components, and development workflows.
  * Added LLM-focused documentation resources to the README.
  * Removed Docker integration and related guidance sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->