### PR TITLE
Use override() in Compiler and remove BuiltinModule from CompilerModule

### DIFF
--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -42,7 +42,7 @@ final class Compiler
      */
     public function compile(AbstractModule $module, string $scriptDir): Scripts
     {
-        $module->install(new CompilerModule($scriptDir));
+        $module->override(new CompilerModule($scriptDir));
 
         // Lock
         $fp = fopen($scriptDir . '/compile.lock', 'a+');

--- a/src/CompilerModule.php
+++ b/src/CompilerModule.php
@@ -8,7 +8,6 @@ use Override;
 use Ray\Compiler\Annotation\Compile;
 use Ray\Di\AbstractModule;
 use Ray\Di\Annotation\ScriptDir;
-use Ray\Di\BuiltinModule;
 use Ray\Di\InjectorInterface;
 use Ray\Di\Scope;
 

--- a/src/CompilerModule.php
+++ b/src/CompilerModule.php
@@ -33,7 +33,6 @@ final class CompilerModule extends AbstractModule
     protected function configure(): void
     {
         $this->bind()->annotatedWith(Compile::class)->toInstance(true);
-        $this->install((new BuiltinModule())($this));
         $this->bind('')->annotatedWith(ScriptDir::class)->toInstance($this->scriptDir);
         $this->bind(InjectorInterface::class)->to(CompiledInjector::class)->in(Scope::SINGLETON);
         (new FilePutContents())(sprintf('%s/_bindings.log', $this->scriptDir), (string) $this);

--- a/tests/CompilerModuleOverrideTest.php
+++ b/tests/CompilerModuleOverrideTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Ray\Compiler\Fake\MultiBindings\FakeMultiBindingsModule;
+use Ray\Compiler\MultiBindings\FakeEngineInterface;
+use Ray\Compiler\MultiBindings\FakeMultiBindingConsumer;
+use Ray\Di\AbstractModule;
+use Ray\Di\InjectorInterface;
+use Ray\Di\MultiBinder;
+use Ray\Di\MultiBinding\Map;
+use Ray\Di\Scope;
+
+use function assert;
+use function mkdir;
+use function is_dir;
+
+class CompilerModuleOverrideTest extends TestCase
+{
+    private string $scriptDir;
+
+    protected function setUp(): void
+    {
+        $this->scriptDir = __DIR__ . '/tmp/compiler-module-override';
+        if (! is_dir($this->scriptDir)) {
+            mkdir($this->scriptDir, 0777, true);
+        }
+    }
+
+    /**
+     * Test 1: InjectorInterface replacement
+     *
+     * When user module binds InjectorInterface to a custom implementation,
+     * CompilerModule should override it to use CompiledInjector instead.
+     */
+    public function testInjectorInterfaceOverride(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                // User accidentally or intentionally binds InjectorInterface
+                $this->bind(InjectorInterface::class)->to(FakeCustomInjector::class)->in(Scope::SINGLETON);
+            }
+        };
+
+        (new Compiler())->compile($module, $this->scriptDir);
+        $injector = new CompiledInjector($this->scriptDir);
+
+        // The injector should get CompiledInjector, not FakeCustomInjector
+        $retrievedInjector = $injector->getInstance(InjectorInterface::class);
+        $this->assertInstanceOf(CompiledInjector::class, $retrievedInjector);
+        $this->assertNotInstanceOf(FakeCustomInjector::class, $retrievedInjector);
+    }
+
+    /**
+     * Test 2: MultiBinding with override()
+     *
+     * CompilerModule uses override() to replace bindings, but this should not
+     * break MultiBinder functionality. MultiBindings should still work correctly.
+     *
+     * @requires PHP 8.0
+     */
+    public function testMultiBindingWithOverride(): void
+    {
+        $scriptDir = __DIR__ . '/tmp/multi-binding-override';
+        if (! is_dir($scriptDir)) {
+            mkdir($scriptDir, 0777, true);
+        }
+
+        (new Compiler())->compile(new FakeMultiBindingsModule(), $scriptDir);
+        $injector = new CompiledInjector($scriptDir);
+
+        /** @var FakeMultiBindingConsumer $consumer */
+        $consumer = $injector->getInstance(FakeMultiBindingConsumer::class);
+
+        // Verify that MultiBinding Map was created correctly
+        $this->assertInstanceOf(Map::class, $consumer->engines);
+
+        // Verify that the map contains the expected bindings
+        $engines = $consumer->engines;
+        $this->assertCount(3, $engines);
+        $this->assertArrayHasKey('one', $engines);
+        $this->assertArrayHasKey('two', $engines);
+    }
+
+    /**
+     * Test 3: Combined test - MultiBinding with InjectorInterface override
+     *
+     * This ensures that when a module uses both MultiBinding and binds InjectorInterface,
+     * CompilerModule's override() correctly:
+     * 1. Replaces InjectorInterface with CompiledInjector
+     * 2. Preserves MultiBinding configurations
+     */
+    public function testMultiBindingWithInjectorOverride(): void
+    {
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                // User binds InjectorInterface
+                $this->bind(InjectorInterface::class)->to(FakeCustomInjector::class);
+
+                // User also uses MultiBinding for engines
+                $engineBinder = MultiBinder::newInstance($this, FakeEngineInterface::class);
+                $engineBinder->addBinding('test')->to(\Ray\Compiler\MultiBindings\FakeEngine::class);
+
+                // User also uses MultiBinding for robots (required by FakeMultiBindingConsumer)
+                $robotBinder = MultiBinder::newInstance($this, \Ray\Compiler\MultiBindings\FakeRobotInterface::class);
+                $robotBinder->addBinding('test')->to(\Ray\Compiler\MultiBindings\FakeRobot::class);
+
+                $this->bind(FakeMultiBindingConsumer::class);
+                $this->bind(\Ray\Compiler\MultiBindings\FakeEngine::class);
+                $this->bind(\Ray\Compiler\MultiBindings\FakeRobot::class);
+            }
+        };
+
+        $scriptDir = __DIR__ . '/tmp/combined-override';
+        if (! is_dir($scriptDir)) {
+            mkdir($scriptDir, 0777, true);
+        }
+
+        (new Compiler())->compile($module, $scriptDir);
+        $injector = new CompiledInjector($scriptDir);
+
+        // Verify InjectorInterface is CompiledInjector
+        $retrievedInjector = $injector->getInstance(InjectorInterface::class);
+        $this->assertInstanceOf(CompiledInjector::class, $retrievedInjector);
+
+        // Verify MultiBinding still works
+        /** @var FakeMultiBindingConsumer $consumer */
+        $consumer = $injector->getInstance(FakeMultiBindingConsumer::class);
+        $this->assertInstanceOf(Map::class, $consumer->engines);
+        $this->assertArrayHasKey('test', $consumer->engines);
+    }
+}
+
+/**
+ * Fake custom injector for testing override behavior
+ */
+class FakeCustomInjector implements InjectorInterface
+{
+    public function getInstance($interface, $name = '')
+    {
+        throw new \LogicException('This injector should be overridden by CompilerModule');
+    }
+}

--- a/tests/CompilerModuleOverrideTest.php
+++ b/tests/CompilerModuleOverrideTest.php
@@ -4,32 +4,25 @@ declare(strict_types=1);
 
 namespace Ray\Compiler;
 
+use LogicException;
 use PHPUnit\Framework\TestCase;
 use Ray\Compiler\Fake\MultiBindings\FakeMultiBindingsModule;
+use Ray\Compiler\MultiBindings\FakeEngine;
 use Ray\Compiler\MultiBindings\FakeEngineInterface;
 use Ray\Compiler\MultiBindings\FakeMultiBindingConsumer;
+use Ray\Compiler\MultiBindings\FakeRobot;
+use Ray\Compiler\MultiBindings\FakeRobotInterface;
 use Ray\Di\AbstractModule;
 use Ray\Di\InjectorInterface;
 use Ray\Di\MultiBinder;
 use Ray\Di\MultiBinding\Map;
 use Ray\Di\Scope;
 
-use function assert;
-use function mkdir;
 use function is_dir;
+use function mkdir;
 
 class CompilerModuleOverrideTest extends TestCase
 {
-    private string $scriptDir;
-
-    protected function setUp(): void
-    {
-        $this->scriptDir = __DIR__ . '/tmp/compiler-module-override';
-        if (! is_dir($this->scriptDir)) {
-            mkdir($this->scriptDir, 0777, true);
-        }
-    }
-
     /**
      * Test 1: InjectorInterface replacement
      *
@@ -38,6 +31,11 @@ class CompilerModuleOverrideTest extends TestCase
      */
     public function testInjectorInterfaceOverride(): void
     {
+        $scriptDir = __DIR__ . '/tmp/compiler-module-override';
+        if (! is_dir($scriptDir)) {
+            mkdir($scriptDir, 0777, true);
+        }
+
         $module = new class extends AbstractModule {
             protected function configure(): void
             {
@@ -46,13 +44,12 @@ class CompilerModuleOverrideTest extends TestCase
             }
         };
 
-        (new Compiler())->compile($module, $this->scriptDir);
-        $injector = new CompiledInjector($this->scriptDir);
+        (new Compiler())->compile($module, $scriptDir);
+        $injector = new CompiledInjector($scriptDir);
 
         // The injector should get CompiledInjector, not FakeCustomInjector
         $retrievedInjector = $injector->getInstance(InjectorInterface::class);
         $this->assertInstanceOf(CompiledInjector::class, $retrievedInjector);
-        $this->assertNotInstanceOf(FakeCustomInjector::class, $retrievedInjector);
     }
 
     /**
@@ -104,15 +101,15 @@ class CompilerModuleOverrideTest extends TestCase
 
                 // User also uses MultiBinding for engines
                 $engineBinder = MultiBinder::newInstance($this, FakeEngineInterface::class);
-                $engineBinder->addBinding('test')->to(\Ray\Compiler\MultiBindings\FakeEngine::class);
+                $engineBinder->addBinding('test')->to(FakeEngine::class);
 
                 // User also uses MultiBinding for robots (required by FakeMultiBindingConsumer)
-                $robotBinder = MultiBinder::newInstance($this, \Ray\Compiler\MultiBindings\FakeRobotInterface::class);
-                $robotBinder->addBinding('test')->to(\Ray\Compiler\MultiBindings\FakeRobot::class);
+                $robotBinder = MultiBinder::newInstance($this, FakeRobotInterface::class);
+                $robotBinder->addBinding('test')->to(FakeRobot::class);
 
                 $this->bind(FakeMultiBindingConsumer::class);
-                $this->bind(\Ray\Compiler\MultiBindings\FakeEngine::class);
-                $this->bind(\Ray\Compiler\MultiBindings\FakeRobot::class);
+                $this->bind(FakeEngine::class);
+                $this->bind(FakeRobot::class);
             }
         };
 
@@ -143,6 +140,6 @@ class FakeCustomInjector implements InjectorInterface
 {
     public function getInstance($interface, $name = '')
     {
-        throw new \LogicException('This injector should be overridden by CompilerModule');
+        throw new LogicException('This injector should be overridden by CompilerModule');
     }
 }

--- a/tests/CompilerModuleOverrideTest.php
+++ b/tests/CompilerModuleOverrideTest.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Ray\Compiler;
 
-use LogicException;
 use PHPUnit\Framework\TestCase;
+use Ray\Compiler\Fake\FakeCustomInjector;
 use Ray\Compiler\Fake\MultiBindings\FakeMultiBindingsModule;
 use Ray\Compiler\MultiBindings\FakeEngine;
 use Ray\Compiler\MultiBindings\FakeEngineInterface;
@@ -129,16 +129,5 @@ class CompilerModuleOverrideTest extends TestCase
         $consumer = $injector->getInstance(FakeMultiBindingConsumer::class);
         $this->assertInstanceOf(Map::class, $consumer->engines);
         $this->assertArrayHasKey('test', $consumer->engines);
-    }
-}
-
-/**
- * Fake custom injector for testing override behavior
- */
-class FakeCustomInjector implements InjectorInterface
-{
-    public function getInstance($interface, $name = '')
-    {
-        throw new LogicException('This injector should be overridden by CompilerModule');
     }
 }

--- a/tests/CompilerModuleOverrideTest.php
+++ b/tests/CompilerModuleOverrideTest.php
@@ -21,6 +21,7 @@ use Ray\Di\Scope;
 use function is_dir;
 use function mkdir;
 
+/** @requires PHP 8.0 */
 class CompilerModuleOverrideTest extends TestCase
 {
     /**
@@ -57,8 +58,6 @@ class CompilerModuleOverrideTest extends TestCase
      *
      * CompilerModule uses override() to replace bindings, but this should not
      * break MultiBinder functionality. MultiBindings should still work correctly.
-     *
-     * @requires PHP 8.0
      */
     public function testMultiBindingWithOverride(): void
     {

--- a/tests/Fake/FakeCustomInjector.php
+++ b/tests/Fake/FakeCustomInjector.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\Fake;
+
+use LogicException;
+use Ray\Di\InjectorInterface;
+
+/**
+ * Fake custom injector for testing override behavior
+ */
+final class FakeCustomInjector implements InjectorInterface
+{
+    /**
+     * @param class-string $interface
+     * @param string       $name
+     *
+     * @return never
+     */
+    public function getInstance($interface, $name = '')
+    {
+        throw new LogicException('This injector should be overridden by CompilerModule');
+    }
+}


### PR DESCRIPTION
## Summary
- Change `Compiler` to use `override()` instead of `install()` for CompilerModule
- Remove `BuiltinModule` installation from CompilerModule
- Add comprehensive tests for override behavior

## Problem
When using `install()`, if a user module binds `InjectorInterface` to a custom implementation, CompilerModule cannot replace it with `CompiledInjector`. This could lead to incorrect injector being used at runtime.

Additionally, installing `BuiltinModule` in CompilerModule was causing MultiBinding to fail with "Undefined array key" errors.

## Solution
1. **Use override() in Compiler**: Ensures CompilerModule's bindings take precedence, particularly for `InjectorInterface`
2. **Remove BuiltinModule**: This was causing conflicts with MultiBinding functionality

## Tests Added
- `CompilerModuleOverrideTest::testInjectorInterfaceOverride()`: Verifies that even when user module binds InjectorInterface, CompiledInjector is used
- `CompilerModuleOverrideTest::testMultiBindingWithOverride()`: Ensures MultiBinding works correctly with override()
- `CompilerModuleOverrideTest::testMultiBindingWithInjectorOverride()`: Combined test for both scenarios

All existing tests pass (82 tests, 138 assertions).

## Impact
This change ensures that:
- CompilerModule always successfully replaces InjectorInterface with CompiledInjector
- MultiBinding functionality is preserved
- No breaking changes for existing code

Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Ensure CompilerModule bindings take precedence by switching to override(), remove BuiltinModule to fix multi-binding conflicts, and add tests to verify correct override behavior and multi-binding preservation.

Enhancements:
- Switch Compiler to use override() for CompilerModule and remove BuiltinModule to prevent binding conflicts

Tests:
- Add tests to verify InjectorInterface is overridden to CompiledInjector
- Add tests to ensure MultiBinding works correctly with override()
- Add a combined test for MultiBinding alongside InjectorInterface override

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched module initialization from an install to an override pattern.
  * Removed automatic builtin module initialization during configuration.

* **Tests**
  * Added tests validating module override behavior, injector replacement, and multi-binding scenarios to ensure overrides produce the expected runtime bindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->