### PR TITLE
Fix array handling in CompileVisitor to prevent premature var_export

### DIFF
--- a/src/CompileVisitor.php
+++ b/src/CompileVisitor.php
@@ -72,7 +72,7 @@ final class CompileVisitor implements VisitorInterface
             return sprintf('return %s;', var_export($value, true));
         }
 
-        assert(is_object($value), 'Invalid instance type:' . gettype($value));
+        assert(is_object($value ) || is_array($value), 'Invalid instance type:' . gettype($value));
 
         return sprintf('return unserialize(\'%s\');', serialize($value));
     }

--- a/src/CompileVisitor.php
+++ b/src/CompileVisitor.php
@@ -72,7 +72,7 @@ final class CompileVisitor implements VisitorInterface
             return sprintf('return %s;', var_export($value, true));
         }
 
-        assert(is_object($value ) || is_array($value), 'Invalid instance type:' . gettype($value));
+        assert(is_object($value) || is_array($value), 'Invalid instance type:' . gettype($value));
 
         return sprintf('return unserialize(\'%s\');', serialize($value));
     }

--- a/src/CompileVisitor.php
+++ b/src/CompileVisitor.php
@@ -68,7 +68,7 @@ final class CompileVisitor implements VisitorInterface
     #[Override]
     public function visitInstance($value): string
     {
-        if ($value === null || is_scalar($value) || is_array($value)) {
+        if ($value === null || is_scalar($value)) {
             return sprintf('return %s;', var_export($value, true));
         }
 

--- a/tests/VisitorCompilerTest.php
+++ b/tests/VisitorCompilerTest.php
@@ -50,17 +50,8 @@ EOT;
     {
         $dependencyInstance = new Instance([1, 2, 3]);
         $code = $dependencyInstance->accept($this->visitor);
-        $expected = <<<'EOT'
-return array (
-  0 => 1,
-  1 => 2,
-  2 => 3,
-);
-EOT;
-        $this->assertSame(
-            $this->normalizeLineEndings($expected),
-            $this->normalizeLineEndings($code)
-        );
+        $expected = "return unserialize('a:3:{i:0;i:1;i:1;i:2;i:2;i:3;}');";
+        $this->assertSame($expected, $code);
     }
 
     public function testDependencyCompile(): Container


### PR DESCRIPTION
var_export call unexpected behavior when array contains objects.

Close #125

## Summary by Sourcery

Bug Fixes:
- Remove is_array check in visitInstance to avoid var_export on arrays with objects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instance value handling: arrays are now accepted alongside objects and are no longer emitted as code literals. Array values are now preserved and returned via a safe round-trip representation to avoid incorrect literal emission and maintain data integrity. Validation broadened to accept arrays where previously rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->