### PR TITLE
Add test for arrays containing objects (#125)

### DIFF
--- a/tests/VisitorCompilerTest.php
+++ b/tests/VisitorCompilerTest.php
@@ -54,6 +54,23 @@ EOT;
         $this->assertSame($expected, $code);
     }
 
+    public function testInstanceCompileArrayWithObjects(): void
+    {
+        $object = new FakeEngine();
+        $dependencyInstance = new Instance([$object, '__invoke']);
+        $code = $dependencyInstance->accept($this->visitor);
+
+        // Should use unserialize and not crash with var_export
+        $this->assertStringContainsString('return unserialize(', $code);
+
+        // Verify it can be executed and reconstructed
+        $result = eval($code);
+        $this->assertIsArray($result);
+        $this->assertCount(2, $result);
+        $this->assertInstanceOf(FakeEngine::class, $result[0]);
+        $this->assertSame('__invoke', $result[1]);
+    }
+
     public function testDependencyCompile(): Container
     {
         $module = new FakeCarModule();


### PR DESCRIPTION
## Summary
- Adds `testInstanceCompileArrayWithObjects()` to validate the fix for issue #125
- Ensures arrays containing objects are properly serialized with `unserialize()` instead of `var_export()`
- Tests the specific case that caused fatal errors: arrays like `[new DeleteCookieInvoker(), '__invoke']`

## Why This Test Is Important
The original fix (#126) changed the behavior but only had a test for simple scalar arrays `[1, 2, 3]`. This PR adds a test for the actual bug case - arrays containing objects - which would have failed with the old `var_export()` approach.

## Test Coverage
- ✅ Verifies code uses `unserialize()` for arrays with objects
- ✅ Validates the serialized code can be executed without errors
- ✅ Confirms the reconstructed array maintains object integrity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tests:
- Add testInstanceCompileArrayWithObjects to verify that arrays with object callbacks are serialized via unserialize and can be reconstructed without errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test validating serialization and reconstruction of arrays with object method references, ensuring correct code generation and runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->