### PR TITLE
Fix correct typo in variable and directory name in DependencySaver

### DIFF
--- a/src-deprecated/DependencySaver.php
+++ b/src-deprecated/DependencySaver.php
@@ -45,7 +45,7 @@ final class DependencySaver
 
     private function saveQualifier(IpQualifier $qualifer): void
     {
-        $qualifier = $this->scriptDir . '/qualifer';
+        $qualifier = $this->scriptDir . '/qualifier';
         ! file_exists($qualifier) && ! @mkdir($qualifier) && ! is_dir($qualifier);
         $class = $qualifer->param->getDeclaringClass();
         if (! $class instanceof ReflectionClass) {


### PR DESCRIPTION
`qualifer` ディレクトリと `qualifier` ディレクトリができている。

```
cd $DOCUMENT_ROOT/var/tmp/prod-html-app/di
ls -1
...
...
...
_bindings.log
_compile.log
_module.txt
compiled
qualifer
qualifier
```

## Summary by Sourcery

Bug Fixes:
- Correct the output directory name for qualifier data to prevent writing to a misspelled path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a directory path misspelling that was causing path resolution errors in qualifier functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->