### PR TITLE
Share the injector singleton cache and cache singletons before PostConstruct

### DIFF
--- a/src/CompiledInjector.php
+++ b/src/CompiledInjector.php
@@ -9,6 +9,7 @@ use Ray\Compiler\Exception\InvalidQualifier;
 use Ray\Compiler\Exception\ScriptDirNotReadable;
 use Ray\Compiler\Exception\Unbound;
 use Ray\Di\Annotation\ScriptDir;
+use Ray\Di\InjectorInterface;
 use Ray\Di\Name;
 
 use function file_exists;
@@ -66,11 +67,13 @@ final class CompiledInjector implements ScriptInjectorInterface
 
         /** @psalm-var ScriptDir $realPath */
         $this->scriptDir = $realPath;
+        $this->cacheInjector();
         $this->registerLoader();
     }
 
     public function __wakeup()
     {
+        $this->cacheInjector();
         $this->registerLoader();
     }
 
@@ -109,6 +112,11 @@ final class CompiledInjector implements ScriptInjectorInterface
 
         /** @psalm-var T $instance */
         return $instance;
+    }
+
+    private function cacheInjector(): void
+    {
+        $this->singletons[InjectorInterface::class . '-' . Name::ANY] = $this;
     }
 
     private function registerLoader(): void

--- a/src/InstanceScript.php
+++ b/src/InstanceScript.php
@@ -160,16 +160,17 @@ final class InstanceScript
 
     public function getScript(string|null $postConstruct, bool $isSingleton): string
     {
-        if (is_string($postConstruct)) {
-            $this->pushPostConstruct($postConstruct, $isSingleton);
-        }
-
-        if ($this->implementsSetContext) {
-            $this->laterLines[] = sprintf('$instance->setContext(%s);', var_export($this->context, true));
+        $initLines = $this->initializationLines($postConstruct);
+        // A singleton must be resolvable from its own initialization, so it is cached before
+        // initialization runs. Every step after that assignment shares one rollback: the cache
+        // entry must never outlive a failed initialization.
+        $isProvisional = $isSingleton && $initLines !== [];
+        foreach ($isProvisional ? self::provisionalLines($initLines) : $initLines as $line) {
+            $this->laterLines[] = $line;
         }
 
         $this->laterLines[] = self::COMMENT;
-        if ($isSingleton && ! is_string($postConstruct)) {
+        if ($isSingleton && ! $isProvisional) {
             $this->laterLines[] = '$singletons[$dependencyIndex] = $instance;';
         }
 
@@ -182,20 +183,42 @@ final class InstanceScript
         return $script;
     }
 
-    private function pushPostConstruct(string $postConstruct, bool $isSingleton): void
+    /**
+     * Lifecycle calls that run on the constructed instance
+     *
+     * @return list<string>
+     */
+    private function initializationLines(string|null $postConstruct): array
     {
-        if (! $isSingleton) {
-            $this->laterLines[] = sprintf('$instance->%s();', $postConstruct);
-
-            return;
+        $lines = [];
+        if (is_string($postConstruct)) {
+            $lines[] = sprintf('$instance->%s();', $postConstruct);
         }
 
-        $this->laterLines[] = '$singletons[$dependencyIndex] = $instance;';
-        $this->laterLines[] = 'try {';
-        $this->laterLines[] = sprintf('    $instance->%s();', $postConstruct);
-        $this->laterLines[] = '} catch (\Throwable $e) {';
-        $this->laterLines[] = '    unset($singletons[$dependencyIndex]);';
-        $this->laterLines[] = '    throw $e;';
-        $this->laterLines[] = '}';
+        if ($this->implementsSetContext) {
+            $lines[] = sprintf('$instance->setContext(%s);', var_export($this->context, true));
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @param list<string> $initLines
+     *
+     * @return list<string>
+     */
+    private static function provisionalLines(array $initLines): array
+    {
+        $lines = ['$singletons[$dependencyIndex] = $instance;', 'try {'];
+        foreach ($initLines as $line) {
+            $lines[] = '    ' . $line;
+        }
+
+        $lines[] = '} catch (\Throwable $e) {';
+        $lines[] = '    unset($singletons[$dependencyIndex]);';
+        $lines[] = '    throw $e;';
+        $lines[] = '}';
+
+        return $lines;
     }
 }

--- a/src/InstanceScript.php
+++ b/src/InstanceScript.php
@@ -161,7 +161,7 @@ final class InstanceScript
     public function getScript(string|null $postConstruct, bool $isSingleton): string
     {
         if (is_string($postConstruct)) {
-            $this->laterLines[] = sprintf('$instance->%s();', $postConstruct);
+            $this->pushPostConstruct($postConstruct, $isSingleton);
         }
 
         if ($this->implementsSetContext) {
@@ -169,7 +169,7 @@ final class InstanceScript
         }
 
         $this->laterLines[] = self::COMMENT;
-        if ($isSingleton) {
+        if ($isSingleton && ! is_string($postConstruct)) {
             $this->laterLines[] = '$singletons[$dependencyIndex] = $instance;';
         }
 
@@ -180,5 +180,22 @@ final class InstanceScript
         $this->laterLines = [];
 
         return $script;
+    }
+
+    private function pushPostConstruct(string $postConstruct, bool $isSingleton): void
+    {
+        if (! $isSingleton) {
+            $this->laterLines[] = sprintf('$instance->%s();', $postConstruct);
+
+            return;
+        }
+
+        $this->laterLines[] = '$singletons[$dependencyIndex] = $instance;';
+        $this->laterLines[] = 'try {';
+        $this->laterLines[] = sprintf('    $instance->%s();', $postConstruct);
+        $this->laterLines[] = '} catch (\Throwable $e) {';
+        $this->laterLines[] = '    unset($singletons[$dependencyIndex]);';
+        $this->laterLines[] = '    throw $e;';
+        $this->laterLines[] = '}';
     }
 }

--- a/tests/Fake/FakeFailingPostConstructSingleton.php
+++ b/tests/Fake/FakeFailingPostConstructSingleton.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+use Ray\Di\Di\PostConstruct;
+use RuntimeException;
+
+final class FakeFailingPostConstructSingleton
+{
+    public static int $constructorCalls = 0;
+    public static int $postConstructCalls = 0;
+    public bool $initialized = false;
+
+    public function __construct()
+    {
+        self::$constructorCalls++;
+    }
+
+    #[PostConstruct]
+    public function initialize(): void
+    {
+        self::$postConstructCalls++;
+        if (self::$postConstructCalls === 1) {
+            throw new RuntimeException('PostConstruct failed');
+        }
+
+        $this->initialized = true;
+    }
+
+    public static function reset(): void
+    {
+        self::$constructorCalls = 0;
+        self::$postConstructCalls = 0;
+    }
+}

--- a/tests/Fake/FakeFailingSetContextSingleton.php
+++ b/tests/Fake/FakeFailingSetContextSingleton.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+use Ray\Di\Di\PostConstruct;
+use Ray\Di\SetContextInterface;
+use RuntimeException;
+
+final class FakeFailingSetContextSingleton implements SetContextInterface
+{
+    public static int $constructorCalls = 0;
+    public static int $setContextCalls = 0;
+    public bool $initialized = false;
+
+    public function __construct()
+    {
+        self::$constructorCalls++;
+    }
+
+    #[PostConstruct]
+    public function initialize(): void
+    {
+        $this->initialized = true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setContext($context)
+    {
+        self::$setContextCalls++;
+        if (self::$setContextCalls === 1) {
+            throw new RuntimeException('setContext failed');
+        }
+    }
+
+    public static function reset(): void
+    {
+        self::$constructorCalls = 0;
+        self::$setContextCalls = 0;
+    }
+}

--- a/tests/Fake/FakePostConstructDependent.php
+++ b/tests/Fake/FakePostConstructDependent.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+final class FakePostConstructDependent
+{
+    public function __construct(public readonly FakePostConstructSingleton $singleton)
+    {
+    }
+}

--- a/tests/Fake/FakePostConstructSingleton.php
+++ b/tests/Fake/FakePostConstructSingleton.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+use Ray\Di\Di\PostConstruct;
+use Ray\Di\InjectorInterface;
+use RuntimeException;
+
+use function assert;
+
+final class FakePostConstructSingleton
+{
+    public static int $postConstructCalls = 0;
+    public FakePostConstructDependent|null $dependent = null;
+
+    public function __construct(private readonly InjectorInterface $injector)
+    {
+    }
+
+    #[PostConstruct]
+    public function initialize(): void
+    {
+        self::$postConstructCalls++;
+        if (self::$postConstructCalls > 1) {
+            throw new RuntimeException('Recursive PostConstruct call');
+        }
+
+        $dependent = $this->injector->getInstance(FakePostConstructDependent::class);
+        assert($dependent instanceof FakePostConstructDependent);
+        $this->dependent = $dependent;
+    }
+
+    public static function reset(): void
+    {
+        self::$postConstructCalls = 0;
+    }
+}

--- a/tests/SingletonPostConstructTest.php
+++ b/tests/SingletonPostConstructTest.php
@@ -26,6 +26,7 @@ final class SingletonPostConstructTest extends TestCase
 
         deleteFiles($scriptDir);
         FakeFailingPostConstructSingleton::reset();
+        FakeFailingSetContextSingleton::reset();
         FakePostConstructSingleton::reset();
 
         $module = new class extends AbstractModule {
@@ -34,6 +35,7 @@ final class SingletonPostConstructTest extends TestCase
                 $this->bind(FakePostConstructSingleton::class)->in(Scope::SINGLETON);
                 $this->bind(FakePostConstructDependent::class);
                 $this->bind(FakeFailingPostConstructSingleton::class)->in(Scope::SINGLETON);
+                $this->bind(FakeFailingSetContextSingleton::class)->in(Scope::SINGLETON);
             }
         };
         (new Compiler())->compile($module, $scriptDir);
@@ -65,5 +67,23 @@ final class SingletonPostConstructTest extends TestCase
         $this->assertSame(2, FakeFailingPostConstructSingleton::$constructorCalls);
         $this->assertSame(2, FakeFailingPostConstructSingleton::$postConstructCalls);
         $this->assertSame($singleton, $this->injector->getInstance(FakeFailingPostConstructSingleton::class));
+    }
+
+    /** setContext() runs after PostConstruct, so it shares the same rollback. */
+    public function testFailedSetContextIsRemovedFromSingletonCache(): void
+    {
+        try {
+            $this->injector->getInstance(FakeFailingSetContextSingleton::class);
+            $this->fail('The first setContext() call must fail.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('setContext failed', $e->getMessage());
+        }
+
+        $singleton = $this->injector->getInstance(FakeFailingSetContextSingleton::class);
+        $this->assertInstanceOf(FakeFailingSetContextSingleton::class, $singleton);
+        $this->assertTrue($singleton->initialized);
+        $this->assertSame(2, FakeFailingSetContextSingleton::$constructorCalls);
+        $this->assertSame(2, FakeFailingSetContextSingleton::$setContextCalls);
+        $this->assertSame($singleton, $this->injector->getInstance(FakeFailingSetContextSingleton::class));
     }
 }

--- a/tests/SingletonPostConstructTest.php
+++ b/tests/SingletonPostConstructTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Ray\Di\AbstractModule;
+use Ray\Di\InjectorInterface;
+use Ray\Di\Scope;
+use RuntimeException;
+
+use function is_dir;
+use function mkdir;
+
+final class SingletonPostConstructTest extends TestCase
+{
+    private CompiledInjector $injector;
+
+    protected function setUp(): void
+    {
+        $scriptDir = __DIR__ . '/tmp/singleton-post-construct';
+        if (! is_dir($scriptDir)) {
+            mkdir($scriptDir, 0777, true);
+        }
+
+        deleteFiles($scriptDir);
+        FakeFailingPostConstructSingleton::reset();
+        FakePostConstructSingleton::reset();
+
+        $module = new class extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakePostConstructSingleton::class)->in(Scope::SINGLETON);
+                $this->bind(FakePostConstructDependent::class);
+                $this->bind(FakeFailingPostConstructSingleton::class)->in(Scope::SINGLETON);
+            }
+        };
+        (new Compiler())->compile($module, $scriptDir);
+        $this->injector = new CompiledInjector($scriptDir);
+    }
+
+    public function testSingletonIsAvailableDuringPostConstruct(): void
+    {
+        $singleton = $this->injector->getInstance(FakePostConstructSingleton::class);
+        $this->assertInstanceOf(FakePostConstructSingleton::class, $singleton);
+        $this->assertInstanceOf(FakePostConstructDependent::class, $singleton->dependent);
+        $this->assertSame($singleton, $singleton->dependent->singleton);
+        $this->assertSame(1, FakePostConstructSingleton::$postConstructCalls);
+        $this->assertSame($this->injector, $this->injector->getInstance(InjectorInterface::class));
+    }
+
+    public function testFailedPostConstructIsRemovedFromSingletonCache(): void
+    {
+        try {
+            $this->injector->getInstance(FakeFailingPostConstructSingleton::class);
+            $this->fail('The first PostConstruct call must fail.');
+        } catch (RuntimeException $e) {
+            $this->assertSame('PostConstruct failed', $e->getMessage());
+        }
+
+        $singleton = $this->injector->getInstance(FakeFailingPostConstructSingleton::class);
+        $this->assertInstanceOf(FakeFailingPostConstructSingleton::class, $singleton);
+        $this->assertTrue($singleton->initialized);
+        $this->assertSame(2, FakeFailingPostConstructSingleton::$constructorCalls);
+        $this->assertSame(2, FakeFailingPostConstructSingleton::$postConstructCalls);
+        $this->assertSame($singleton, $this->injector->getInstance(FakeFailingPostConstructSingleton::class));
+    }
+}


### PR DESCRIPTION
## Summary

- make the active `CompiledInjector` its own `InjectorInterface` singleton, so an injected injector shares the injector's singleton cache
- cache compiled singleton instances before invoking `PostConstruct`, matching Ray.Di's caching order
- remove a singleton from the cache when a lifecycle call throws, preserving the retry behavior compiled code has today

## Root cause

Two independent defects, both reproduced against the current `1.x`.

### Injected `InjectorInterface` did not share the singleton cache

`CompilerModule` binds `InjectorInterface` to `CompiledInjector`, so the generated `Ray_Di_InjectorInterface-.php` constructs a *new* `CompiledInjector` with an empty `$singletons`. Any class that injects `InjectorInterface` and resolves lazily therefore received a different instance than the outer injector had cached. This breaks the singleton contract on its own, with no `PostConstruct` involved:

|                                 | `1.x`   | this PR | Ray.Di `Injector` |
|---------------------------------|---------|---------|-------------------|
| injected injector === outer     | `false` | `true`  | `true`            |
| singleton identity preserved    | `false` | `true`  | `true`            |

`Injector::__construct()` binds `InjectorInterface` to `$this` *after* the container is built, so the injector always wins over a user binding of the same interface. `cacheInjector()` reproduces that, including the precedence.

### Singletons were cached only after `PostConstruct`

`Ray\Di\Dependency::inject()` assigns `$this->instance` *before* calling the `PostConstruct` method. Generated scripts assigned `$singletons[$dependencyIndex]` afterwards, so a lifecycle method that resolved a dependency back to its own singleton started constructing the same object again — unbounded re-entry where the runtime injector simply returns the instance under construction.

## Behavior

The generated script for a singleton with lifecycle calls now caches the instance, runs the
lifecycle calls, and on `Throwable` removes the cache entry before rethrowing. `setContext()`
runs after `PostConstruct`, so both share the same rollback — otherwise a failed
`setContext()` would leave a half-initialized singleton cached, which `1.x` does not do.

Note that the rollback is **not** Ray.Di runtime parity — it preserves what compiled code already does. Ray.Di keeps the instance cached when `PostConstruct` throws, so a retry there returns the half-initialized object without re-running the lifecycle method:

|                              | `1.x` compiled | this PR | Ray.Di `Injector` |
|------------------------------|----------------|---------|-------------------|
| constructor calls after retry| 2              | 2       | 1                 |
| `PostConstruct` calls        | 2              | 2       | 1                 |
| instance initialized         | `true`         | `true`  | `false`           |

Retry-from-scratch looks like the better contract, so this keeps it rather than regressing to Ray.Di's behavior. Aligning the two implementations is tracked in ray-di/Ray.Di#343. The rollback is intentionally local to the singleton whose lifecycle method failed: other successfully created singletons and external side effects are not treated as a transaction, consistent with the container's existing resolution model.

## Validation

Rebased onto `1.x` (`18dcae7`); the `ScriptName::forIndex()` escaping from #139 is untouched.

- `composer cs` — 48 files, no errors
- `vendor/bin/phpunit` — 122 tests, 224 assertions
- PHPStan — no errors
- Psalm (PHP 8.4) — no errors, 99.82% inferred types
- coverage — `InstanceScript` and `CompiledInjector` stay at 100% methods and lines
- reverting `cacheInjector()`, the provisional caching, or either rollback scope each makes the new regression tests fail
