### PR TITLE
Add CompiledInjector::warmup() for eager singleton initialization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,11 @@ This document explains Ray.Di's module system, dependency resolution, scope mana
    - Stores script index -> PHP code mapping
    - Writes scripts to files named by dependency index (e.g., `Interface-name.php`)
 
+6. **Singleton metadata** (`singletons.json`): Written by Compiler alongside the scripts
+   - Lists every singleton dependency index that can be built without caller context
+   - AOP `MethodInvocation` bindings are excluded because they exist only during interception
+   - Compilation rejects injection-point-dependent singletons
+
 ### Runtime Execution
 
 1. **CompiledInjector** (`src/CompiledInjector.php`): Minimal injector that executes pre-compiled code
@@ -60,6 +65,8 @@ This document explains Ray.Di's module system, dependency resolution, scope mana
    - Registers autoloader for compiled classes
    - Script files named as: `ClassName-bindingName.php`
    - This minimal approach eliminates all Ray.Di runtime overhead
+   - `warmup()` eagerly instantiates every singleton listed in `singletons.json`; call it before concurrent request handling (e.g. coroutine worker start) so lazy singleton initialization cannot race
+   - Compilation throws `SingletonRequiresInjectionPoint` when a singleton requires caller context; use prototype scope or remove the injection-point dependency
 
 2. **Scope Functions** (`src-function/`): Helper functions used in compiled scripts
    - `singleton()`: Returns cached instance or requires script file (singleton scope)
@@ -145,6 +152,15 @@ InjectionPoint class reconstructs ReflectionParameter from this array.
 
 ## PHP Version Support
 Requires PHP 7.2+ or 8.0+. Code uses both annotations and attributes (PHP 8 attributes via `#[...]` syntax).
+
+## Comments
+
+Keep comments sparse. This codebase favors near-zero comment density (e.g. `src/Scripts.php` has none).
+
+- Comment only the *why* that the code cannot express; never narrate *what* the code does.
+- Prefer one-line docblocks. Multi-paragraph explanations belong in commit messages or docs, not source.
+- Add `@param`/`@return`/`@var` only when they carry type information the signature cannot (Psalm/PHPStan types).
+- No restating the method name in prose, no conversational or changelog-style comments.
 
 ## Compiled Output Should Not Be Committed
 The `/tmp/di/` or similar compiled script directories should be in `.gitignore`. Compilation happens during deployment/build, not development.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ Add compile script to your `composer.json`:
 }
 ```
 
+### Warming Up Singletons
+
+Compilation also generates `singletons.json`, a list of singleton bindings that can be instantiated without caller context. `CompiledInjector::warmup()` instantiates them all eagerly:
+
+```php
+$injector = new CompiledInjector($scriptDir);
+$injector->warmup(); // call once at worker startup
+```
+
+In a long-lived or coroutine runtime (Swoole, OpenSwoole), lazy singleton initialization can race when construction yields, producing duplicate instances. Calling `warmup()` before concurrent request handling begins removes that window.
+
+This is only needed for runtimes that handle requests concurrently within one process. Standard PHP-FPM workers normally process one request at a time, so no warm-up is required there.
+
+An injection-point-dependent singleton would capture whichever consumer constructs it first, making the shared instance order-dependent. Such bindings must use prototype scope or remove the injection-point dependency.
+
+- Compilation throws `SingletonRequiresInjectionPoint` for an injection-point-dependent singleton.
+- `warmup()` throws `SingletonsFileNotFound` if `singletons.json` is missing. Recompile with the current Ray.Compiler version.
+
 ## Version Control
 
 Compiled DI code is considered an environment-specific build artifact and **should not** be committed to version control. This approach ensures that your repository remains clean and build artifacts do not cause merge conflicts or unexpected behavior across different environments.
@@ -88,4 +106,3 @@ Add the compile directory to your `.gitignore`:
 - **[Performance & OPcache](docs/performance.md)** - Why the compiled injector is fast, the OPcache prerequisite, and how to benchmark it correctly
 - **[LLM Documentation](https://ray-di.github.io/Ray.Compiler/llms.txt)** - Brief documentation optimized for LLMs
 - **[Complete LLM Documentation](https://ray-di.github.io/Ray.Compiler/llms-full.txt)** - Full documentation with architecture details
-

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -57,6 +57,11 @@ Compilation Flow
    - Stores script index -> PHP code mapping
    - Writes scripts to files named by dependency index (e.g., Interface-name.php)
 
+6. Singleton metadata (singletons.json): Written by Compiler alongside the scripts
+   - Lists every singleton dependency index that can be built without caller context
+   - AOP MethodInvocation bindings are excluded because they exist only during interception
+   - Compilation rejects injection-point-dependent singletons
+
 Runtime Execution
 ~~~~~~~~~~~~~~~~~
 
@@ -68,6 +73,7 @@ Runtime Execution
    - Registers autoloader for compiled classes
    - Script files named as: ClassName-bindingName.php
    - This minimal approach eliminates all Ray.Di runtime overhead
+   - warmup() eagerly instantiates every singleton listed in singletons.json; call it before concurrent request handling (e.g. coroutine worker start) so lazy singleton initialization cannot race
 
 2. Scope Functions (src-function/): Helper functions used in compiled scripts
    - singleton(): Returns cached instance or requires script file (singleton scope)
@@ -138,6 +144,23 @@ Add compile script to your composer.json:
     }
 }
 ```
+
+Warming Up Singletons
+~~~~~~~~~~~~~~~~~~~~~
+
+Compilation also generates singletons.json, a list of singleton bindings that can be instantiated without caller context. CompiledInjector::warmup() instantiates them all eagerly:
+
+```php
+$injector = new CompiledInjector($scriptDir);
+$injector->warmup(); // call once at worker startup
+```
+
+In a long-lived or coroutine runtime (Swoole, OpenSwoole), lazy singleton initialization can race when construction yields, producing duplicate instances. Calling warmup() before concurrent request handling begins removes that window.
+
+This is only needed for runtimes that handle requests concurrently within one process. Standard PHP-FPM workers normally process one request at a time, so no warm-up is required there.
+
+- Compilation throws SingletonRequiresInjectionPoint if a singleton requires a caller injection point. Use prototype scope or remove the injection-point dependency.
+- warmup() throws SingletonsFileNotFound if singletons.json is missing. Recompile with the current Ray.Compiler version.
 
 Deployment
 ----------

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -44,6 +44,18 @@ $injector = new CompiledInjector($scriptDir);
 $instance = $injector->getInstance(YourInterface::class);
 ```
 
+Warming Up Singletons
+---------------------
+Compilation also generates singletons.json, a list of singleton bindings that can be instantiated without caller context. In a coroutine runtime (Swoole, OpenSwoole), lazy singleton initialization can race when construction yields; call warmup() once at worker startup to remove that window. Standard PHP-FPM workers normally process one request at a time, so no warm-up is required there.
+
+```php
+$injector = new CompiledInjector($scriptDir);
+$injector->warmup();
+```
+
+- Compilation throws SingletonRequiresInjectionPoint if a singleton requires a caller injection point. Use prototype scope or remove the injection-point dependency.
+- warmup() throws SingletonsFileNotFound if singletons.json is missing. Recompile with the current Ray.Compiler version.
+
 Core Components
 ---------------
 
@@ -57,6 +69,7 @@ Core Components
    - Does NOT use reflection - all necessary metadata embedded in compiled scripts
    - getInstance() simply constructs file path and executes script via require
    - Manages singleton instances in $singletons array
+   - warmup() eagerly instantiates every singleton listed in singletons.json
 
 3. Scope Functions (src-function/):
    - singleton(): Returns cached instance or requires script file (singleton scope)

--- a/src/CompileVisitor.php
+++ b/src/CompileVisitor.php
@@ -17,14 +17,18 @@ use ReflectionParameter;
 
 use function assert;
 use function gettype;
+use function implode;
 use function is_array;
 use function is_object;
 use function is_scalar;
 use function is_string;
 use function serialize;
 use function sprintf;
-use function str_replace;
+use function strrpos;
+use function substr;
 use function var_export;
+
+use const PHP_EOL;
 
 final class CompileVisitor implements VisitorInterface
 {
@@ -33,6 +37,11 @@ final class CompileVisitor implements VisitorInterface
     public function __construct(Container $container)
     {
         $this->script = new InstanceScript($container);
+    }
+
+    public function consumeInjectionPointUsage(): bool
+    {
+        return $this->script->consumeInjectionPointUsage();
     }
 
     /** @inheritDoc */
@@ -57,10 +66,10 @@ final class CompileVisitor implements VisitorInterface
         $this->script->pushProviderContext($context);
         $script = $dependency->accept($this);
         assert(is_string($script));
+        $pos = strrpos($script, InstanceScript::RETURN_INSTANCE);
+        assert($pos !== false);
 
-        $providerScript = $this->getProviderScript($isSingleton);
-
-        return str_replace(InstanceScript::COMMENT, $providerScript, $script);
+        return substr($script, 0, $pos) . $this->getProviderScript($isSingleton);
     }
 
     /** @inheritDoc */
@@ -143,17 +152,13 @@ final class CompileVisitor implements VisitorInterface
 
     private function getProviderScript(bool $isSingleton): string
     {
+        $lines = ['$instance = $instance->get();'];
         if ($isSingleton) {
-            return <<<'EOT'
-$instance = $instance->get();
-// singleton
-$singletons[$dependencyIndex] = $instance;
-EOT;
+            $lines[] = '$singletons[$dependencyIndex] = $instance;';
         }
 
-        return <<<'EOT'
-$instance = $instance->get();
-// prototype
-EOT;
+        $lines[] = InstanceScript::RETURN_INSTANCE;
+
+        return implode(PHP_EOL, $lines);
     }
 }

--- a/src/CompiledInjector.php
+++ b/src/CompiledInjector.php
@@ -7,18 +7,24 @@ namespace Ray\Compiler;
 use Override;
 use Ray\Compiler\Exception\InvalidQualifier;
 use Ray\Compiler\Exception\ScriptDirNotReadable;
+use Ray\Compiler\Exception\SingletonsFileNotFound;
 use Ray\Compiler\Exception\Unbound;
 use Ray\Di\Annotation\ScriptDir;
 use Ray\Di\InjectorInterface;
 use Ray\Di\Name;
 
+use function explode;
 use function file_exists;
+use function file_get_contents;
 use function in_array;
 use function is_dir;
 use function is_readable;
+use function json_decode;
 use function realpath;
 use function spl_autoload_register;
 use function sprintf;
+
+use const JSON_THROW_ON_ERROR;
 
 /**
  * Compiled Injector
@@ -33,6 +39,8 @@ use function sprintf;
  */
 final class CompiledInjector implements ScriptInjectorInterface
 {
+    public const SINGLETONS_FILE = 'singletons.json';
+
     /** @var ScriptDir */
     private readonly string $scriptDir;
 
@@ -112,6 +120,30 @@ final class CompiledInjector implements ScriptInjectorInterface
 
         /** @psalm-var T $instance */
         return $instance;
+    }
+
+    /**
+     * Call before concurrent request handling (e.g. coroutine worker start) so that lazy
+     * singleton initialization cannot race. A failure aborts with the original exception.
+     *
+     * @throws SingletonsFileNotFound The script dir was not compiled with singleton metadata.
+     */
+    public function warmup(): void
+    {
+        $file = $this->scriptDir . '/' . self::SINGLETONS_FILE;
+        if (! file_exists($file)) {
+            // A silent no-op would leave the caller believing the race protection is active
+            throw new SingletonsFileNotFound($file);
+        }
+
+        /** @var list<string> $indexes */
+        $indexes = json_decode((string) file_get_contents($file), true, 512, JSON_THROW_ON_ERROR);
+        foreach ($indexes as $index) {
+            $parts = explode('-', $index, 2);
+            /** @var ''|class-string $interface */
+            $interface = $parts[0];
+            $this->getInstance($interface, $parts[1] ?? Name::ANY);
+        }
     }
 
     private function cacheInjector(): void

--- a/src/Compiler.php
+++ b/src/Compiler.php
@@ -5,17 +5,22 @@ declare(strict_types=1);
 namespace Ray\Compiler;
 
 use Ray\Compiler\Exception\CompileLockFailed;
+use Ray\Compiler\Exception\SingletonRequiresInjectionPoint;
 use Ray\Di\AbstractModule;
 use Ray\Di\AcceptInterface;
 use Ray\Di\Annotation\ScriptDir;
 use Ray\Di\ContainerFactory;
+use Ray\Di\Dependency;
 use Ray\Di\DependencyInterface;
+use Ray\Di\DependencyProvider;
 
 use function assert;
 use function fclose;
 use function flock;
 use function fopen;
+use function in_array;
 use function is_string;
+use function json_encode;
 
 use const LOCK_EX;
 use const LOCK_UN;
@@ -33,6 +38,9 @@ use const LOCK_UN;
  */
 final class Compiler
 {
+    /** Indexes resolvable only inside a caller context (AOP interception) */
+    private const CONTEXT_SENSITIVE = ['Ray\Aop\MethodInvocation-'];
+
     /**
      * Compiles a given module into Scripts
      *
@@ -44,7 +52,6 @@ final class Compiler
     {
         $module->override(new CompilerModule($scriptDir));
 
-        // Lock
         $fp = fopen($scriptDir . '/compile.lock', 'a+');
         if ($fp === false || ! flock($fp, LOCK_EX)) {
             // @codeCoverageIgnoreStart
@@ -60,7 +67,8 @@ final class Compiler
         $container = (new ContainerFactory())($module, $scriptDir);
         // Compile dependencies
         $compileVisitor = new CompileVisitor($container);
-        $container->map(static function (DependencyInterface $dependency, string $key) use ($scripts, $compileVisitor): DependencyInterface {
+        $singletonIndexes = [];
+        $container->map(static function (DependencyInterface $dependency, string $key) use ($scripts, $compileVisitor, &$singletonIndexes): DependencyInterface {
             assert($dependency instanceof AcceptInterface);
             if ($key === InstanceScript::RAY_DI_SCRIPT_DIR) {
                 $scripts->add($key, 'return __DIR__;');
@@ -70,15 +78,37 @@ final class Compiler
 
             $script = $dependency->accept($compileVisitor);
             assert(is_string($script));
+            $injectionPointUsed = $compileVisitor->consumeInjectionPointUsage();
+            if ($injectionPointUsed && self::isSingletonDependency($dependency)) {
+                throw new SingletonRequiresInjectionPoint($key);
+            }
+
             $scripts->add($key, $script);
+            if (self::isWarmupCandidate($dependency, $key)) {
+                $singletonIndexes[] = $key;
+            }
 
             return $dependency;
         });
         $scripts->save($scriptDir);
-        // Unlock
+        (new FilePutContents())($scriptDir . '/' . CompiledInjector::SINGLETONS_FILE, (string) json_encode($singletonIndexes));
         flock($fp, LOCK_UN);
         fclose($fp);
 
         return $scripts;
+    }
+
+    private static function isWarmupCandidate(DependencyInterface $dependency, string $key): bool
+    {
+        if (in_array($key, self::CONTEXT_SENSITIVE, true)) {
+            return false;
+        }
+
+        return self::isSingletonDependency($dependency);
+    }
+
+    private static function isSingletonDependency(DependencyInterface $dependency): bool
+    {
+        return ($dependency instanceof Dependency || $dependency instanceof DependencyProvider) && $dependency->isSingleton();
     }
 }

--- a/src/Exception/InjectionPointNotAvailable.php
+++ b/src/Exception/InjectionPointNotAvailable.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\Exception;
+
+use LogicException;
+
+/** Thrown when resolving an InjectionPoint without caller context; the message is the dependency index. */
+final class InjectionPointNotAvailable extends LogicException implements ExceptionInterface
+{
+}

--- a/src/Exception/SingletonRequiresInjectionPoint.php
+++ b/src/Exception/SingletonRequiresInjectionPoint.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\Exception;
+
+use LogicException;
+
+/** Thrown for an InjectionPoint-dependent singleton; the message is its dependency index and prototype scope is required. */
+final class SingletonRequiresInjectionPoint extends LogicException implements ExceptionInterface
+{
+}

--- a/src/Exception/SingletonsFileNotFound.php
+++ b/src/Exception/SingletonsFileNotFound.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler\Exception;
+
+use RuntimeException;
+
+final class SingletonsFileNotFound extends RuntimeException implements ExceptionInterface
+{
+}

--- a/src/InstanceScript.php
+++ b/src/InstanceScript.php
@@ -32,7 +32,7 @@ final class InstanceScript
     public const RAY_DI_INJECTOR_INTERFACE = 'Ray\Di\InjectorInterface-';
     public const RAY_DI_INJECTION_POINT_INTERFACE = 'Ray\Di\InjectionPointInterface-';
     public const RAY_DI_SCRIPT_DIR = '-Ray\Di\Annotation\ScriptDir';
-    public const COMMENT = '// prototype';
+    public const RETURN_INSTANCE = 'return $instance;';
 
     /** @var array<mixed> */
     private array $args = [];
@@ -44,6 +44,7 @@ final class InstanceScript
     private array $laterLines = [];  // Setter injection and postConstruct
     private string $context = '';
     private bool $implementsSetContext = false;
+    private bool $injectionPointUsed = false;
 
     /** @var array<DependencyInterface> */
     private array $container;
@@ -73,7 +74,8 @@ final class InstanceScript
             }
 
             if ($index === self::RAY_DI_INJECTION_POINT_INTERFACE) {
-                $this->args[] = '\Ray\Compiler\InjectionPoint::getInstance($ip)';
+                $this->args[] = '\Ray\Compiler\InjectionPoint::getInstance($ip ?? throw new \Ray\Compiler\Exception\InjectionPointNotAvailable($dependencyIndex))';
+                $this->injectionPointUsed = true;
 
                 return;
             }
@@ -158,6 +160,14 @@ final class InstanceScript
         $this->formerLines[] = sprintf('$instance->bindings = [%s    %s%s];', PHP_EOL, implode(', ' . PHP_EOL . '    ', $interceptors), PHP_EOL);
     }
 
+    public function consumeInjectionPointUsage(): bool
+    {
+        $used = $this->injectionPointUsed;
+        $this->injectionPointUsed = false;
+
+        return $used;
+    }
+
     public function getScript(string|null $postConstruct, bool $isSingleton): string
     {
         $initLines = $this->initializationLines($postConstruct);
@@ -169,12 +179,11 @@ final class InstanceScript
             $this->laterLines[] = $line;
         }
 
-        $this->laterLines[] = self::COMMENT;
         if ($isSingleton && ! $isProvisional) {
             $this->laterLines[] = '$singletons[$dependencyIndex] = $instance;';
         }
 
-        $this->laterLines[] = 'return $instance;';
+        $this->laterLines[] = self::RETURN_INSTANCE;
 
         $script = implode(PHP_EOL, $this->formerLines) . PHP_EOL . implode(PHP_EOL, $this->laterLines);
         $this->formerLines = [];

--- a/tests/CompiledInjectorTest.php
+++ b/tests/CompiledInjectorTest.php
@@ -6,6 +6,7 @@ namespace Ray\Compiler;
 
 use PHPUnit\Framework\Attributes\Depends;
 use PHPUnit\Framework\TestCase;
+use Ray\Compiler\Exception\InjectionPointNotAvailable;
 use Ray\Compiler\Exception\ScriptDirNotReadable;
 use Ray\Di\Exception\Unbound;
 
@@ -59,6 +60,13 @@ class CompiledInjectorTest extends TestCase
     {
         $instance = $this->injector->getInstance(FakeLoggerConsumer::class);
         $this->assertInstanceOf(FakeLoggerConsumer::class, $instance);
+    }
+
+    public function testInjectionPointNotAvailableWithoutConsumer(): void
+    {
+        $this->expectException(InjectionPointNotAvailable::class);
+        $this->expectExceptionMessage(FakeLoggerInterface::class . '-' . FakeLoggerInject::class);
+        $this->injector->getInstance(FakeLoggerInterface::class, FakeLoggerInject::class);
     }
 
     public function testSingleton(): void

--- a/tests/Fake/FakeIpLiteralDefaultSingleton.php
+++ b/tests/Fake/FakeIpLiteralDefaultSingleton.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+class FakeIpLiteralDefaultSingleton
+{
+    public function __construct(
+        public readonly string $note = 'InjectionPoint::getInstance($ip)',
+    ) {
+    }
+}

--- a/tests/Fake/FakeWarmupCounter.php
+++ b/tests/Fake/FakeWarmupCounter.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+class FakeWarmupCounter
+{
+    public static int $count = 0;
+
+    public function __construct()
+    {
+        self::$count++;
+    }
+}

--- a/tests/VisitorCompilerTest.php
+++ b/tests/VisitorCompilerTest.php
@@ -85,7 +85,6 @@ EOT;
         // Verify the instance is created correctly with array defaults
         $expected = <<<'EOT'
 $instance = new \Ray\Compiler\FakeClassWithArrayDefault(unserialize('a:1:{s:3:"key";s:5:"value";}'), unserialize('a:3:{i:0;i:1;i:1;i:2;i:2;i:3;}'));
-// prototype
 return $instance;
 EOT;
         $this->assertSame($this->normalizeLineEndings($expected), $this->normalizeLineEndings($code));
@@ -107,7 +106,6 @@ $instance->setSpareMirror(\Ray\Compiler\singleton($scriptDir, $singletons, 'Ray\
 $instance->setHandle(\Ray\Compiler\prototype($scriptDir, $singletons, 'Ray\\Compiler\\FakeHandleInterface-', '/Ray_Compiler_FakeHandleInterface-.php', ['Ray\Compiler\FakeCar', 'setHandle', 'handle']));
 $instance->setOil(\Ray\Compiler\prototype($scriptDir, $singletons, 'Ray\\Compiler\\FakeOilInterface-', '/Ray_Compiler_FakeOilInterface-.php', ['Ray\Compiler\FakeCar', 'setOil', 'oil']));
 $instance->postConstruct();
-// prototype
 return $instance;
 EOT;
         $this->assertSame(
@@ -127,7 +125,6 @@ EOT;
         $expected = <<<'EOT'
 $instance = new \Ray\Compiler\FakeHandleProvider('momo');
 $instance = $instance->get();
-// prototype
 return $instance;
 EOT;
         $this->assertSame(
@@ -173,7 +170,6 @@ EOT;
 $instance = new \Ray\Compiler\FakeContextualProvider();
 $instance->setContext('context');
 $instance = $instance->get();
-// prototype
 return $instance;
 EOT;
         $this->assertSame(

--- a/tests/WarmupTest.php
+++ b/tests/WarmupTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\Compiler;
+
+use PHPUnit\Framework\TestCase;
+use Ray\Aop\MethodInvocation;
+use Ray\Compiler\Exception\SingletonRequiresInjectionPoint;
+use Ray\Compiler\Exception\SingletonsFileNotFound;
+use Ray\Di\AbstractModule;
+use Ray\Di\Scope;
+
+use function assert;
+use function file_get_contents;
+use function is_array;
+use function is_dir;
+use function json_decode;
+use function mkdir;
+use function spl_object_hash;
+
+use const JSON_THROW_ON_ERROR;
+
+class WarmupTest extends TestCase
+{
+    /** @var non-empty-string */
+    private string $scriptDir;
+
+    protected function setUp(): void
+    {
+        $this->scriptDir = __DIR__ . '/tmp/warmup';
+        deleteFiles($this->scriptDir);
+        FakeWarmupCounter::$count = 0;
+    }
+
+    /** @return list<string> */
+    private function getSingletonIndexes(): array
+    {
+        $indexes = json_decode((string) file_get_contents($this->scriptDir . '/singletons.json'), true, 512, JSON_THROW_ON_ERROR);
+        assert(is_array($indexes));
+        /** @var list<string> $indexes */
+
+        return $indexes;
+    }
+
+    public function testCompileWritesSingletonsJson(): void
+    {
+        (new Compiler())->compile(new FakeToBindSingletonModule(), $this->scriptDir);
+        $this->assertFileExists($this->scriptDir . '/singletons.json');
+        $indexes = $this->getSingletonIndexes();
+        $this->assertContains(FakeRobotInterface::class . '-', $indexes);
+        $this->assertContains(FakeDependSingleton::class . '-', $indexes);
+    }
+
+    public function testWarmupInstantiatesSingletonsEagerly(): void
+    {
+        $module = new class () extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeWarmupCounter::class)->in(Scope::SINGLETON);
+            }
+        };
+        (new Compiler())->compile($module, $this->scriptDir);
+        $this->assertNotContains(MethodInvocation::class . '-', $this->getSingletonIndexes());
+        $injector = new CompiledInjector($this->scriptDir);
+        $injector->warmup();
+        $this->assertSame(1, FakeWarmupCounter::$count);
+        // the warmed instance is the cached one
+        $instance = $injector->getInstance(FakeWarmupCounter::class);
+        $this->assertSame(spl_object_hash($instance), spl_object_hash($injector->getInstance(FakeWarmupCounter::class)));
+        $this->assertSame(1, FakeWarmupCounter::$count);
+    }
+
+    public function testInjectionPointSingletonFailsCompilationBeforeConsumerCanCacheIt(): void
+    {
+        $module = new class () extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeLoggerInterface::class)->annotatedWith(FakeLoggerInject::class)->toProvider(FakeLoggerPointProvider::class)->in(Scope::SINGLETON);
+                $this->bind(FakeLoggerConsumer::class)->in(Scope::SINGLETON);
+            }
+        };
+        $this->expectException(SingletonRequiresInjectionPoint::class);
+        $this->expectExceptionMessage(FakeLoggerInterface::class . '-' . FakeLoggerInject::class);
+        (new Compiler())->compile($module, $this->scriptDir);
+    }
+
+    public function testIpLiteralInDefaultStringDoesNotExcludeSingleton(): void
+    {
+        $module = new class () extends AbstractModule {
+            protected function configure(): void
+            {
+                $this->bind(FakeIpLiteralDefaultSingleton::class)->in(Scope::SINGLETON);
+            }
+        };
+        (new Compiler())->compile($module, $this->scriptDir);
+        // the default string merely looks like the $ip call; the singleton must still be warmable
+        $this->assertContains(FakeIpLiteralDefaultSingleton::class . '-', $this->getSingletonIndexes());
+    }
+
+    public function testWarmupWithoutSingletonsJson(): void
+    {
+        $emptyDir = __DIR__ . '/tmp/warmup-empty';
+        deleteFiles($emptyDir);
+        if (! is_dir($emptyDir)) {
+            mkdir($emptyDir, 0777, true);
+        }
+
+        $injector = new CompiledInjector($emptyDir);
+        $this->expectException(SingletonsFileNotFound::class);
+        $injector->warmup();
+    }
+}


### PR DESCRIPTION
## Summary

- `Compiler` now writes `singletons.json`: every singleton dependency index (except the AOP `MethodInvocation` binding, which only exists during interception)
- New `CompiledInjector::warmup()` instantiates them eagerly. Call once at worker start in a coroutine runtime (Swoole, OpenSwoole) to close the lazy-initialization race window where a yielding construction lets a second coroutine build a duplicate singleton
- Compilation rejects injection-point-dependent singletons with `SingletonRequiresInjectionPoint` (message: the dependency index). Such bindings are first-consumer-wins by design, and runtime detection during warm-up is unreliable — warming a consumer singleton builds and caches the dependency with a real injection point, so its own index later just hits the cache
- Generated scripts emit `$ip ?? throw new InjectionPointNotAvailable`, so fetching an injection-point binding directly from the root fails with a dedicated exception instead of a bare `TypeError`
- Closes #137 (Ray.Compiler side; BEAR.Package integration to follow separately)

## Design

- The warm-up guarantee is: **`warmup()` returns normally = every compiled singleton is initialized.** Compile-time rejection keeps that guarantee intact without any exclusion list
- Fix for `SingletonRequiresInjectionPoint`: use prototype scope (injection-point bindings should not be singletons)
- `warmup()` throws `SingletonsFileNotFound` when the metadata is missing — a silent no-op would leave callers believing the protection is active
- PHP-FPM never races (each request has its own process), so no warm-up is needed there
- Generated scripts no longer carry `// prototype` / `// singleton` scope comments: they duplicated the `$singletons` write line (and were wrong for singleton `Dependency` scripts), and the comment doubled as the provider-script anchor. Provider composition now splices at the final `return $instance;`

## Note on commits

This branch builds on the unmerged `cache-singleton-before-postconstruct` work (f292847, 8c0b974) — warming `InjectorInterface` relies on its `cacheInjector()` fix — so those two commits appear in this PR.

## Test plan

- `tests/WarmupTest.php`: singletons.json output, eager instantiation, compile-time rejection of injection-point singletons (incl. the consumer-masking order case), missing-metadata exception
- `tests/CompiledInjectorTest.php`: root fetch of an injection-point binding throws `InjectionPointNotAvailable`
- `composer test` / `composer cs` / `composer sa` all green (128 tests, 236 assertions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added singleton warmup during application startup to eagerly initialize eligible services.
  * Added generated metadata to support reliable warmup in concurrent runtimes, including PHP-FPM.
  * Added clear errors for missing warmup metadata and services requiring injection-point context.

* **Documentation**
  * Documented warmup usage, supported runtimes, eligibility rules, exclusions, and related errors.

* **Tests**
  * Added coverage for metadata generation, eager initialization, instance caching, exclusions, and missing metadata handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
