### PR TITLE
Clarify warmup docs target coroutine runtime servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Add compile script to your `composer.json`:
 }
 ```
 
-### Warming Up Singletons
+### Warming Up Singletons on Coroutine Runtime Servers
 
 Compilation also generates `singletons.json`, a list of singleton bindings that can be instantiated without caller context. `CompiledInjector::warmup()` instantiates them all eagerly:
 

--- a/docs/llms-full.txt
+++ b/docs/llms-full.txt
@@ -145,8 +145,8 @@ Add compile script to your composer.json:
 }
 ```
 
-Warming Up Singletons
-~~~~~~~~~~~~~~~~~~~~~
+Warming Up Singletons on Coroutine Runtime Servers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Compilation also generates singletons.json, a list of singleton bindings that can be instantiated without caller context. CompiledInjector::warmup() instantiates them all eagerly:
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -44,8 +44,8 @@ $injector = new CompiledInjector($scriptDir);
 $instance = $injector->getInstance(YourInterface::class);
 ```
 
-Warming Up Singletons
----------------------
+Warming Up Singletons on Coroutine Runtime Servers
+--------------------------------------------------
 Compilation also generates singletons.json, a list of singleton bindings that can be instantiated without caller context. In a coroutine runtime (Swoole, OpenSwoole), lazy singleton initialization can race when construction yields; call warmup() once at worker startup to remove that window. Standard PHP-FPM workers normally process one request at a time, so no warm-up is required there.
 
 ```php


### PR DESCRIPTION
The bare "Warming Up Singletons" section title read as a general recommendation. warmup() is only needed where one injector is shared by concurrent coroutines (Swoole, OpenSwoole); PHP-FPM needs none. Retitles the section in README.md, docs/llms.txt, and docs/llms-full.txt. Mirrors the same fix in ray-di/ray-di.github.io#102.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that singleton warmup applies to coroutine runtime servers such as Swoole and OpenSwoole.
  * Documented that warmup helps prevent lazy initialization races in concurrent environments.
  * Noted that standard PHP-FPM workers do not require singleton warmup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->