### PR TITLE
Accept phar:// script directories

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -56,7 +56,7 @@ return require $file;               // happy path: no stat(), just cached opcode
 A missing compiled script is a build invariant violation (corrupt or incomplete build); PHP 8 makes a
 failed `require` a catchable `Error` that surfaces naturally. `CompiledInjector::getInstance()` keeps its
 `file_exists()` pre-check (it reports unbound interfaces as `Unbound`); its redundant
-`realpath($this->scriptDir)` — already canonicalised in the constructor — was removed.
+`realpath($this->scriptDir)` — already validated in the constructor — was removed.
 
 ## Benchmarking correctly
 

--- a/src/CompiledInjector.php
+++ b/src/CompiledInjector.php
@@ -68,18 +68,18 @@ final class CompiledInjector implements ScriptInjectorInterface
     {
         // realpath() cannot resolve stream URIs such as phar://; keep those as given
         $realPath = realpath($scriptDir);
-        if ($realPath !== false) {
-            $scriptDir = $realPath;
+        if ($realPath === false) {
+            $realPath = $scriptDir;
         }
 
-        if (! is_dir($scriptDir) || ! is_readable($scriptDir)) {
+        if (! is_dir($realPath) || ! is_readable($realPath)) {
             $message = sprintf('Script directory "%s" is not readable. See https://ray-di.github.io/Ray.Compiler/error/ScriptDirNotReadable', $scriptDir);
 
             throw new ScriptDirNotReadable($message);
         }
 
-        /** @psalm-var ScriptDir $scriptDir */
-        $this->scriptDir = $scriptDir;
+        /** @psalm-var ScriptDir $realPath */
+        $this->scriptDir = $realPath;
         $this->cacheInjector();
         $this->registerLoader();
     }

--- a/src/CompiledInjector.php
+++ b/src/CompiledInjector.php
@@ -68,18 +68,18 @@ final class CompiledInjector implements ScriptInjectorInterface
     {
         // realpath() cannot resolve stream URIs such as phar://; keep those as given
         $realPath = realpath($scriptDir);
-        if ($realPath === false) {
-            $realPath = $scriptDir;
+        if ($realPath !== false) {
+            $scriptDir = $realPath;
         }
 
-        if (! is_dir($realPath) || ! is_readable($realPath)) {
+        if (! is_dir($scriptDir) || ! is_readable($scriptDir)) {
             $message = sprintf('Script directory "%s" is not readable. See https://ray-di.github.io/Ray.Compiler/error/ScriptDirNotReadable', $scriptDir);
 
             throw new ScriptDirNotReadable($message);
         }
 
-        /** @psalm-var ScriptDir $realPath */
-        $this->scriptDir = $realPath;
+        /** @psalm-var ScriptDir $scriptDir */
+        $this->scriptDir = $scriptDir;
         $this->cacheInjector();
         $this->registerLoader();
     }

--- a/src/CompiledInjector.php
+++ b/src/CompiledInjector.php
@@ -66,8 +66,13 @@ final class CompiledInjector implements ScriptInjectorInterface
     public function __construct(#[ScriptDir]
     string $scriptDir,)
     {
+        // realpath() cannot resolve stream URIs such as phar://; keep those as given
         $realPath = realpath($scriptDir);
-        if ($realPath === false || ! is_dir($realPath) || ! is_readable($realPath)) {
+        if ($realPath === false) {
+            $realPath = $scriptDir;
+        }
+
+        if (! is_dir($realPath) || ! is_readable($realPath)) {
             $message = sprintf('Script directory "%s" is not readable. See https://ray-di.github.io/Ray.Compiler/error/ScriptDirNotReadable', $scriptDir);
 
             throw new ScriptDirNotReadable($message);
@@ -112,7 +117,7 @@ final class CompiledInjector implements ScriptInjectorInterface
 
         /** @psalm-suppress  UnsupportedPropertyReferenceUsage */
         $singletons = &$this->singletons;
-        $scriptDir = $this->scriptDir; // already realpath()d in the constructor
+        $scriptDir = $this->scriptDir; // validated in the constructor
 
         // $scriptDir, $singletons, and $dependencyIndex can be used in the included file
         /** @var mixed $instance */

--- a/tests/CompiledInjectorTest.php
+++ b/tests/CompiledInjectorTest.php
@@ -10,10 +10,16 @@ use Ray\Compiler\Exception\InjectionPointNotAvailable;
 use Ray\Compiler\Exception\ScriptDirNotReadable;
 use Ray\Di\Exception\Unbound;
 
+use function escapeshellarg;
+use function exec;
+use function implode;
 use function mkdir;
 use function serialize;
 use function spl_object_hash;
+use function sprintf;
 use function unserialize;
+
+use const PHP_BINARY;
 
 /** @psalm-import-type ScriptDir from CompiledInjector */
 class CompiledInjectorTest extends TestCase
@@ -110,5 +116,30 @@ class CompiledInjectorTest extends TestCase
         $this->expectException(ScriptDirNotReadable::class);
         $this->expectExceptionMessage($scriptDir);
         new CompiledInjector($scriptDir);
+    }
+
+    /**
+     * realpath() returns false for phar:// paths, but compiled scripts are
+     * relocatable (see ScriptDirRelocationTest) and phars can carry them.
+     */
+    public function testScriptDirInsidePhar(): void
+    {
+        $scriptDir = __DIR__ . '/tmp/' . __FUNCTION__;
+        @mkdir($scriptDir);
+        (new Compiler())->compile(new FakeModule(), $scriptDir);
+        $pharFile = $scriptDir . '/app.phar';
+        // The test process runs with phar.readonly=1; build in a child that does not
+        exec(sprintf(
+            '%s -d phar.readonly=0 %s %s %s 2>&1',
+            escapeshellarg(PHP_BINARY),
+            escapeshellarg(__DIR__ . '/script/build_phar.php'),
+            escapeshellarg($scriptDir),
+            escapeshellarg($pharFile),
+        ), $output, $exitCode);
+        $this->assertSame(0, $exitCode, implode("\n", $output));
+
+        $injector = new CompiledInjector('phar://' . $pharFile . '/di');
+        $instance = $injector->getInstance(FakeCarInterface::class);
+        $this->assertInstanceOf(FakeCarInterface::class, $instance);
     }
 }

--- a/tests/CompiledInjectorTest.php
+++ b/tests/CompiledInjectorTest.php
@@ -127,7 +127,7 @@ class CompiledInjectorTest extends TestCase
         $scriptDir = __DIR__ . '/tmp/' . __FUNCTION__;
         @mkdir($scriptDir);
         (new Compiler())->compile(new FakeModule(), $scriptDir);
-        $pharFile = $scriptDir . '/app.phar';
+        $pharFile = $scriptDir . '.phar'; // outside $scriptDir so the build never globs its own output
         // The test process runs with phar.readonly=1; build in a child that does not
         exec(sprintf(
             '%s -d phar.readonly=0 %s %s %s 2>&1',

--- a/tests/script/build_phar.php
+++ b/tests/script/build_phar.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Build a phar whose /di directory holds the given compiled scripts.
+ *
+ * Run with -d phar.readonly=0; the test suite itself runs read-only.
+ *
+ * argv: [1] compiled script directory (flat), [2] phar file to create
+ */
+
+declare(strict_types=1);
+
+$phar = new Phar($argv[2]);
+$phar->startBuffering();
+foreach (array_filter((array) glob($argv[1] . '/*')) as $file) {
+    $phar->addFile($file, 'di/' . basename($file));
+}
+
+$phar->stopBuffering();

--- a/tests/script/build_phar.php
+++ b/tests/script/build_phar.php
@@ -10,6 +10,7 @@
 
 declare(strict_types=1);
 
+@unlink($argv[2]); // Phar appends to an existing archive; start clean
 $phar = new Phar($argv[2]);
 $phar->startBuffering();
 foreach (array_filter((array) glob($argv[1] . '/*')) as $file) {


### PR DESCRIPTION
## Problem

`CompiledInjector::__construct()` canonicalizes the script directory with `realpath()`, which returns `false` for stream URIs such as `phar://`. Booting from AOT scripts packaged inside a phar therefore threw `ScriptDirNotReadable` even though the directory is readable:

```text
Uncaught Ray\Compiler\Exception\ScriptDirNotReadable: Script directory
"phar://app.phar/var/tmp/prod-app/di" is not readable.
```

This was the last blocker for phar deployment of a compiled BEAR.Sunday app (bearsunday/BEAR.Package#426): with this one line patched, a prod app boots read-only from `app.phar` end to end.

## Fix

Fall back to the given path when `realpath()` fails and let the existing `is_dir()`/`is_readable()` checks decide. A missing real directory still fails both checks, so `testThrowsScriptDirNotReadableException` behavior is unchanged.

Compiled scripts bake no absolute paths (`ScriptDirRelocationTest`), so a phar can carry them as-is.

## Test

`testScriptDirInsidePhar` compiles `FakeModule`, packages the scripts into a phar in a child process (the suite runs with `phar.readonly=1`), and resolves an instance through `phar://`.

## Checklist

- ✅ `composer test` (129 tests)
- ✅ `composer cs`
- ✅ `composer sa`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of compiled injectors loaded from Phar archives.
  * Preserved valid script paths when canonical path resolution is unavailable, while continuing to validate that directories exist and are readable.

* **Tests**
  * Added coverage for resolving dependencies from compiled injectors packaged inside Phar archives.

* **Documentation**
  * Clarified script directory validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->